### PR TITLE
Makefile: added coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,3 +20,11 @@ jobs:
 
     - name: Test
       run: make test
+
+    - name: Coverage
+      run: make test-create-coverage
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: test-coverage
+        path: coverage.html

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.html
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,20 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: manifests generate fmt vet ## Run tests.
+test: manifests generate fmt vet test-fast ## Run tests.
+
+TEST_PACKAGES := ./...
+ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
+test-fast:
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test  ./... -coverprofile cover.out --v -ginkgo.v -ginkgo.progress
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test  $(TEST_PACKAGES) -coverprofile cover.out --v -ginkgo.v -ginkgo.progress
+
+test-create-coverage:
+	go tool cover --html=cover.out -o coverage.html
+
+test-coverage:
+	go tool cover --html=cover.out
 
 vendor:
 	go mod tidy


### PR DESCRIPTION
This commits adds a few changes in Makefile:

* `make test-fast`: this is a target to avoid create all manifest,
  verbose etc.. Also added a way to test a specific package,  like:

  ```
  make test-fast TEST_PACKAGES='./internal/yggdrasil'
  make test-fast
  ```

* `make test-create-coverage`: This create a coverage.out html file
  where you can check the coverage.

* `make test-coverage`: it will open a browser window with the coverage
  information.

Also adds coverage on GitHub Actions.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>