### PR TITLE
CI: Add coverage check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,6 @@
 name: Go
-
+permissions:
+  actions: write
 on:
   push:
     branches: [ main ]
@@ -9,8 +10,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
     - uses: actions/checkout@v2
+
+    - uses: ouzi-dev/commit-status-updater@v1.1.0
+      with:
+        name: "Coverage"
+        ignoreForks: false
+        status: "error"
+        description: "Test coverage: TEST"
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -21,7 +31,17 @@ jobs:
       run: make test
 
     - name: Coverage
-      run: make test-create-coverage
+      run: |
+        make test-create-coverage
+        COVERAGE=$(go tool cover --func=cover.out |  grep total | grep -Eo '[0-9]+\.[0-9]+')
+        echo "testCoverage=${COVERAGE}" >> $GITHUB_ENV
+
+    - uses: ouzi-dev/commit-status-updater@v1.1.0
+      with:
+        name: "Coverage"
+        ignoreForks: false
+        status: "${{ env.testCoverage > 80 && 'success' || 'error' }}"
+        description: "Test coverage: ${{ env.testCoverage }}%"
 
     - name: Checking generated files are up to date
       run: |
@@ -31,7 +51,6 @@ jobs:
       with:
         name: test-coverage
         path: coverage.html
-
 
   lint-code:
     name: Lint code


### PR DESCRIPTION
On a new PR, a new check will be added with the percent of the test
coverage, it'll fail if the coverage is smaller than 80%.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>