### PR TITLE
System metrics allow-list namespace

### DIFF
--- a/api/v1alpha1/edgedevice_types.go
+++ b/api/v1alpha1/edgedevice_types.go
@@ -52,7 +52,7 @@ type SystemMetricsConfiguration struct {
 
 	// AllowList defines name and namespace of a ConfigMap containing
 	// list of system metrics that should be scraped
-	AllowList *ObjectRef `json:"allowList,omitempty"`
+	AllowList *NameRef `json:"allowList,omitempty"`
 
 	// Disabled when set to true instructs the device to turn off system metrics collection
 	Disabled bool `json:"disabled,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -842,7 +842,7 @@ func (in *SystemMetricsConfiguration) DeepCopyInto(out *SystemMetricsConfigurati
 	*out = *in
 	if in.AllowList != nil {
 		in, out := &in.AllowList, &out.AllowList
-		*out = new(ObjectRef)
+		*out = new(NameRef)
 		**out = **in
 	}
 }

--- a/config/crd/bases/management.project-flotta.io_edgedevices.yaml
+++ b/config/crd/bases/management.project-flotta.io_edgedevices.yaml
@@ -78,8 +78,6 @@ spec:
                         properties:
                           name:
                             type: string
-                          namespace:
-                            type: string
                         required:
                         - name
                         type: object

--- a/docs/user-guide/device-metrics.md
+++ b/docs/user-guide/device-metrics.md
@@ -50,5 +50,4 @@ spec:
     system:
       allowList: 
           name: system-allow-list
-          namespace: devices
 ```

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -263,7 +263,7 @@ func (h *Handler) getDeviceMetricsConfiguration(ctx context.Context, edgeDevice 
 
 		allowListSpec := systemMetrics.AllowList
 		if allowListSpec != nil {
-			allowList, err := h.allowLists.GenerateFromConfigMap(ctx, allowListSpec.Name, allowListSpec.Namespace)
+			allowList, err := h.allowLists.GenerateFromConfigMap(ctx, allowListSpec.Name, edgeDevice.Namespace)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/yggdrasil/yggdrasil_test.go
+++ b/internal/yggdrasil/yggdrasil_test.go
@@ -1441,10 +1441,7 @@ var _ = Describe("Yggdrasil", func() {
 
 		It("should map system metrics", func() {
 			// given
-			const (
-				allowListName      = "a-name"
-				allowListNamespace = "a-namespace"
-			)
+			const allowListName = "a-name"
 			interval := int32(3600)
 
 			device := getDevice("foo")
@@ -1452,9 +1449,8 @@ var _ = Describe("Yggdrasil", func() {
 				SystemMetrics: &v1alpha1.SystemMetricsConfiguration{
 					Interval: interval,
 					Disabled: true,
-					AllowList: &v1alpha1.ObjectRef{
-						Name:      allowListName,
-						Namespace: allowListNamespace,
+					AllowList: &v1alpha1.NameRef{
+						Name: allowListName,
 					},
 				},
 			}
@@ -1465,7 +1461,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			allowList := models.MetricsAllowList{Names: []string{"fizz", "buzz"}}
-			allowListsMock.EXPECT().GenerateFromConfigMap(gomock.Any(), allowListName, allowListNamespace).
+			allowListsMock.EXPECT().GenerateFromConfigMap(gomock.Any(), allowListName, device.Namespace).
 				Return(&allowList, nil)
 
 			// when
@@ -1488,22 +1484,18 @@ var _ = Describe("Yggdrasil", func() {
 
 		It("should fail when allow-list generation fails", func() {
 			// given
-			const (
-				allowListName      = "a-name"
-				allowListNamespace = "a-namespace"
-			)
+			const allowListName = "a-name"
 
 			device := getDevice("foo")
 			device.Spec.Metrics = &v1alpha1.MetricsConfiguration{
 				SystemMetrics: &v1alpha1.SystemMetricsConfiguration{
-					AllowList: &v1alpha1.ObjectRef{
-						Name:      allowListName,
-						Namespace: allowListNamespace,
+					AllowList: &v1alpha1.NameRef{
+						Name: allowListName,
 					},
 				},
 			}
 
-			allowListsMock.EXPECT().GenerateFromConfigMap(gomock.Any(), allowListName, allowListNamespace).
+			allowListsMock.EXPECT().GenerateFromConfigMap(gomock.Any(), allowListName, device.Namespace).
 				Return(nil, fmt.Errorf("boom!"))
 
 			edgeDeviceRepoMock.EXPECT().


### PR DESCRIPTION
Requiring system metrics allow-list to be placed in the same namespace as EdgeDevice using it.

Related to ECOPROJECT-516.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>