### PR TITLE
Authfile secret namespace restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ Run `make run` to start the operator.
 
 In order to change the verbosity of the logger check out [here](docs/user-guide/logger.md). 
 
-For additional resources check out: [metrics](docs/metrics/metrics.md), [grafana dashboard](docs/metrics/grafana.md), [device metrics](docs/user-guide/device-metrics.md).
+For additional resources check out: [metrics](docs/metrics/metrics.md), [grafana dashboard](docs/metrics/grafana.md), [device metrics](docs/user-guide/device-metrics.md), [image registries](docs/user-guide/image-registries-auth.md).

--- a/api/v1alpha1/edgedeployment_types.go
+++ b/api/v1alpha1/edgedeployment_types.go
@@ -36,7 +36,7 @@ type EdgeDeploymentSpec struct {
 }
 
 type ImageRegistriesConfiguration struct {
-	AuthFileSecret *ObjectRef `json:"secretRef,omitempty"`
+	AuthFileSecret *NameRef `json:"secretRef,omitempty"`
 }
 
 type MetricsConfigEntity struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -561,7 +561,7 @@ func (in *ImageRegistriesConfiguration) DeepCopyInto(out *ImageRegistriesConfigu
 	*out = *in
 	if in.AuthFileSecret != nil {
 		in, out := &in.AuthFileSecret, &out.AuthFileSecret
-		*out = new(ObjectRef)
+		*out = new(NameRef)
 		**out = **in
 	}
 }

--- a/config/crd/bases/management.project-flotta.io_edgedeployments.yaml
+++ b/config/crd/bases/management.project-flotta.io_edgedeployments.yaml
@@ -106,8 +106,6 @@ spec:
                     properties:
                       name:
                         type: string
-                      namespace:
-                        type: string
                     required:
                     - name
                     type: object

--- a/docs/user-guide/image-registries-auth.md
+++ b/docs/user-guide/image-registries-auth.md
@@ -1,0 +1,40 @@
+# Container Image Registries Credentials
+
+Container images used by `EdgeDeployments` may be hosted in private, protected repositories requiring clients to present 
+correct credentials. Users can provide said credentials to Flotta operator as a `Secret` referred to by an `EdgeDeployment`.
+
+Secret should contain correct docker auth file under the `.dockerconfigjson` key:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pull-secret
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: ewoJImF1dGhzIjogewoJCSJxdWF5LmlvIjogewoJCQkiYXV0aCI6ICJabTl2SUdKaGNpQm1iMjhnWW1GeUNnPT0iCgkJfQoJfQp9Cg==
+```
+
+where `.dockerconfigjson` is a base64 encoded Docker auth file JSON:
+
+```json
+{
+  "auths": {
+    "quay.io": {
+      "auth": "Zm9vIGJhciBmb28gYmFyCg=="
+    }
+  }
+}
+```
+
+The above JSON can be taken from file created by running `podman login`, `docker login` or similar.
+
+Secret created above must be placed in the same namespace as `EdgeDeployment` using it. 
+
+Reference to the above `Secret` in an `EdgeDeployment` spec: 
+
+```yaml
+spec:
+  imageRegistries:
+    secretRef:
+      name: pull-secret
+```

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -468,14 +468,9 @@ func (h *Handler) toWorkloadList(ctx context.Context, logger logr.Logger, deploy
 	return list, nil
 }
 
-func (h *Handler) getAuthFile(ctx context.Context, imageRegistries *v1alpha1.ImageRegistriesConfiguration, defaultNamespace string) (string, error) {
+func (h *Handler) getAuthFile(ctx context.Context, imageRegistries *v1alpha1.ImageRegistriesConfiguration, namespace string) (string, error) {
 	if imageRegistries != nil {
 		if secretRef := imageRegistries.AuthFileSecret; secretRef != nil {
-			namespace := secretRef.Namespace
-			if secretRef.Namespace == "" {
-				namespace = defaultNamespace
-			}
-
 			authFile, err := h.registryAuthRepository.GetAuthFileFromSecret(ctx, namespace, secretRef.Name)
 			if err != nil {
 				return "", err


### PR DESCRIPTION
Requiring image repositories auth file secret to be placed in the same namespace as EdgeDeployment using it.

Related to ECOPROJECT-516.