### PR TITLE
TLS: Support ecdsa keys.

### DIFF
--- a/internal/mtls/caprovider_secret.go
+++ b/internal/mtls/caprovider_secret.go
@@ -72,6 +72,9 @@ func (config *CASecretProvider) GetCACertificate() (*CertificateGroup, error) {
 		// Certificate is already created, parse it as *certificateGroup and return
 		// it
 		certGroup, err := NewCACertificateGroupFromSecret(secret.Data)
+		if err != nil {
+			return nil, err
+		}
 		config.latestCA = certGroup
 		return certGroup, err
 	}
@@ -204,7 +207,7 @@ func (config *CASecretProvider) SignCSR(CSRPem string, commonName string, expira
 	// one maybe it's an attack.
 	decodecCert, _ := pem.Decode([]byte(CSRPem))
 	if decodecCert == nil {
-		return nil, fmt.Errorf("Cannot decode CSR certificate")
+		return nil, fmt.Errorf("cannot decode CSR certificate")
 	}
 
 	CSR, err := x509.ParseCertificateRequest(decodecCert.Bytes)

--- a/internal/yggdrasil/yggdrasil_integration_test.go
+++ b/internal/yggdrasil/yggdrasil_integration_test.go
@@ -2,8 +2,9 @@ package yggdrasil_test
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -1959,7 +1960,7 @@ var _ = Describe("Yggdrasil", func() {
 			Context("With certificate", func() {
 
 				createCSR := func() []byte {
-					keys, err := rsa.GenerateKey(rand.Reader, 1024)
+					keys, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 					ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Cannot create key")
 					var csrTemplate = x509.CertificateRequest{
 						Version: 0,
@@ -1967,7 +1968,7 @@ var _ = Describe("Yggdrasil", func() {
 							CommonName:   "test",
 							Organization: []string{"k4e"},
 						},
-						SignatureAlgorithm: x509.SHA512WithRSA,
+						SignatureAlgorithm: x509.ECDSAWithSHA256,
 					}
 					// step: generate the csr request
 					csrCertificate, err := x509.CreateCertificateRequest(rand.Reader, &csrTemplate, keys)


### PR DESCRIPTION
By default, MTLS encryption only uses RSA keys. With this new way, it'll
support RSA and ECDSA keys, that has a better performance for the same
level of encryption.

Fix: ECOPROJECT-541

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>