### PR TITLE
CI: Add coverage check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,4 @@
 name: Go
-
 on:
   push:
     branches: [ main ]
@@ -9,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      coverage: ${{ steps.coverage.outputs.coverage }}
     steps:
     - uses: actions/checkout@v2
 
@@ -21,19 +22,29 @@ jobs:
       run: make test
 
     - name: Coverage
-      run: make test-create-coverage
-
-    - name: Checking generated files are up to date
+      id: coverage
       run: |
-        git diff --quiet config/ internal/ client/ restapi/ || (echo "There are not committed changes"; git diff config/ internal/ client/ restapi/ | tee; exit 1)
+        make test-create-coverage
+        COVERAGE=$(go tool cover --func=cover.out |  grep total | grep -Eo '[0-9]+\.[0-9]+')
+        echo "::set-output name=coverage::${COVERAGE}"
 
     - uses: actions/upload-artifact@v2
       with:
         name: test-coverage
         path: coverage.html
 
+    - name: Checking generated files are up to date
+      run: |
+        git diff --quiet config/ internal/ client/ restapi/ || (echo "There are not committed changes"; git diff config/ internal/ client/ restapi/ | tee; exit 1)
 
-  lint-code:
+  Coverage:
+    needs: build
+    name: "Test Coverage ${{ needs.build.outputs.coverage }}"
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          "echo 'Coverage status: ${{ needs.build.outputs.coverage }}'; exit ${{ needs.build.outputs.coverage > 45 && '0' || '1' }}"
+  Lint:
     name: Lint code
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,7 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          "echo 'Coverage status: ${{ needs.build.outputs.coverage }}'; exit ${{ needs.build.outputs.coverage > 45 && '0' || '1' }}"
+          echo 'Coverage status: ${{ needs.build.outputs.coverage }}'
+          if [ "$TEST" -lt "80" ]; then echo "Min coverage failed"; exit 1; fi
   Lint:
     name: Lint code
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,9 @@ test-fast:
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test  $(TEST_PACKAGES) -coverprofile cover.out --v -ginkgo.v -ginkgo.progress
 
 test-create-coverage:
+	sed -i '/mock_/d' cover.out
+	sed -i '/zz_generated/d' cover.out
+	go tool cover -func cover.out
 	go tool cover --html=cover.out -o coverage.html
 
 test-coverage:


### PR DESCRIPTION
On a new PR, a new check will be added with the percent of the test
coverage, it'll fail if the coverage is smaller than 80%.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>