### PR TITLE
Verify unique containers names

### DIFF
--- a/api/v1alpha1/edgedeployment_webhook_test.go
+++ b/api/v1alpha1/edgedeployment_webhook_test.go
@@ -170,5 +170,40 @@ var _ = Describe("EdgeDeployment Webhook", func() {
 				}
 			}),
 		)
+
+		It("reuse container name", func() {
+			// given
+			podSpec.Containers = append(edgeDeployment.Spec.Pod.Spec.Containers,
+				corev1.Container{
+					Name:            "container",
+					Image:           "stam",
+					ImagePullPolicy: corev1.PullAlways,
+				})
+
+			// when
+			err := edgeDeployment.ValidateCreate()
+
+			// then
+			Expect(err).Should(MatchError("name collisions for containers within the same pod spec are not supported.\n" +
+				"container name: 'container' has been reused"))
+		})
+
+		It("reuse init container name", func() {
+			// given
+			podSpec.InitContainers = append(edgeDeployment.Spec.Pod.Spec.Containers,
+				corev1.Container{
+					Name:            "container",
+					Image:           "stam",
+					ImagePullPolicy: corev1.PullAlways,
+				})
+
+			// when
+			err := edgeDeployment.ValidateCreate()
+
+			// then
+			Expect(err).Should(MatchError("name collisions for containers within the same pod spec are not supported.\n" +
+				"container name: 'container' has been reused"))
+		})
+
 	})
 })


### PR DESCRIPTION
Added verification of unique containers names within the same pod spec.

The uniqueness of the names should be reflected among all the containers (both regular and init containers) within the same pod spec.

This PR relates to the issue described [here](https://issues.redhat.com/browse/ECOPROJECT-439).

Signed-off-by: arielireni <aireni@redhat.com>