### PR TITLE
Add AnsiblePlaybook to DeviceConfigurationMessage

### DIFF
--- a/docs/design/http_api_swagger.md
+++ b/docs/design/http_api_swagger.md
@@ -389,6 +389,7 @@ Status: Internal Server Error
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
+| ansible_playbook | string| `string` |  | |  |  |
 | configuration | [DeviceConfiguration](#device-configuration)| `DeviceConfiguration` |  | |  |  |
 | device_id | string| `string` |  | | Device identifier |  |
 | secrets | [SecretList](#secret-list)| `SecretList` |  | | List of secrets used by the workloads |  |

--- a/models/device_configuration_message.go
+++ b/models/device_configuration_message.go
@@ -17,6 +17,9 @@ import (
 // swagger:model device-configuration-message
 type DeviceConfigurationMessage struct {
 
+	// ansible playbook
+	AnsiblePlaybook string `json:"ansible_playbook,omitempty"`
+
 	// configuration
 	Configuration *DeviceConfiguration `json:"configuration,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -317,6 +317,9 @@ func init() {
     "device-configuration-message": {
       "type": "object",
       "properties": {
+        "ansible_playbook": {
+          "type": "string"
+        },
         "configuration": {
           "$ref": "#/definitions/device-configuration"
         },
@@ -1303,6 +1306,9 @@ func init() {
     "device-configuration-message": {
       "type": "object",
       "properties": {
+        "ansible_playbook": {
+          "type": "string"
+        },
         "configuration": {
           "$ref": "#/definitions/device-configuration"
         },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -158,6 +158,8 @@ definitions:
       secrets:
         $ref: '#/definitions/secret-list'
         description: List of secrets used by the workloads
+      ansible_playbook:
+        type: string
 
   device-configuration:
     type: object


### PR DESCRIPTION
This PR adds AnsiblePlaybook field to the DeviceConfigurationMessage struct.

This change is needed for project-flotta/flotta-device-worker#69

Signed-off-by: Gloria Ciavarrini <gciavarrini@redhat.com>