### PR TITLE
Ignore EdgeDevice status-only changes

### DIFF
--- a/api/v1alpha1/edgedeployment_webhook.go
+++ b/api/v1alpha1/edgedeployment_webhook.go
@@ -96,7 +96,7 @@ func (r *EdgeDeployment) validate() error {
 		}
 
 		if _, ok := containersNames[container.Name]; ok {
-			return fmt.Errorf("name collisions for containers within the same pod spec are not supported.\n" +
+			return fmt.Errorf("name collisions for containers within the same pod spec are not supported.\n"+
 				"container name: '%s' has been reused", container.Name)
 		} else {
 			containersNames[container.Name] = struct{}{}

--- a/controllers/edgedevice_controller.go
+++ b/controllers/edgedevice_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"time"
 
 	obv1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
@@ -126,6 +127,7 @@ func (r *EdgeDeviceReconciler) addObcReference(ctx context.Context, edgeDevice *
 func (r *EdgeDeviceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&managementv1alpha1.EdgeDevice{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }


### PR DESCRIPTION
This PR introduces filtering for the `EdgeDevice` controller - from now on only changes in `EdgeDevice.spec` will trigger reconciliation.

Label changes are handled by the `EdgeDeviceLabelsReconciler`.

As per `GenerationChangedPredicate` documentation:
>  This predicate will skip update events that have no change in the object's metadata.generation field.
>  The metadata.generation field of an object is incremented by the API server when writes are made to the spec field of an object.
> This allows a controller to ignore update events where the spec is unchanged, and only the metadata and/or status fields are changed.
