### PR TITLE
Rename container push job

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -4,7 +4,7 @@ on:
     branches: [ main ]
 
 jobs:
-  kind:
+  container:
     runs-on: ubuntu-latest
     steps:
       - name: Check out proper version of sources


### PR DESCRIPTION
Rename container push job to container rather then kind.

Signed-off-by: Ondra Machacek <omachace@redhat.com>