### PR TITLE
Support podman and its flags in hack/generate

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -9,20 +9,30 @@ set -x
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 __root="$(cd "$(dirname "${__dir}")" && pwd)"
 
+if which podman 2>/dev/null >&2; then
+    export CONTAINER_RUNTIME="podman"
+    export CONTAINER_RUNTIME_OPTS="--userns=keep-id"
+elif which docker 2>/dev/null >&2; then
+    export CONTAINER_RUNTIME="docker"
+else
+    echo No container runtime found, install podman or docker.
+    exit 2
+fi
+
 function generate_go_client() {
     rm -rf client models
-    docker run -u $(id -u):$(id -u) -v ${__root}:${__root}:rw,Z -v /etc/passwd:/etc/passwd -w ${__root} \
+    "${CONTAINER_RUNTIME}" run "${CONTAINER_RUNTIME_OPTS}" -u $(id -u):$(id -u) -v ${__root}:${__root}:rw,Z -v /etc/passwd:/etc/passwd -w ${__root} \
         quay.io/goswagger/swagger:v0.25.0 generate client -f swagger.yaml --template=stratoscale
 }
 
 function generate_go_server() {
     rm -rf restapi
-    docker run -u $(id -u):$(id -u) -v ${__root}:${__root}:rw,Z -v /etc/passwd:/etc/passwd -w ${__root} \
+    "${CONTAINER_RUNTIME}" run "${CONTAINER_RUNTIME_OPTS}" -u $(id -u):$(id -u) -v ${__root}:${__root}:rw,Z -v /etc/passwd:/etc/passwd -w ${__root} \
         quay.io/goswagger/swagger:v0.25.0 generate server  -f ${__root}/swagger.yaml --template=stratoscale
 }
 
 function generate_docs() {
-    docker run -u $(id -u):$(id -u) -v ${__root}:${__root}:rw,Z -v /etc/passwd:/etc/passwd -w ${__root} \
+    "${CONTAINER_RUNTIME}" run "${CONTAINER_RUNTIME_OPTS}" -u $(id -u):$(id -u) -v ${__root}:${__root}:rw,Z -v /etc/passwd:/etc/passwd -w ${__root} \
         quay.io/goswagger/swagger:v0.27.0 generate markdown  -f ${__root}/swagger.yaml --template=stratoscale --output=docs/design/http-api-swagger.md
 }
 


### PR DESCRIPTION
hack/generate.sh will spin a container which tries to create folder on mounted volumes.
When runnign with podman, the containerised process id won't have the right permission because its is running in a different namespace. unless using --userns (thanks to @gciavarrini for suggesting  that)

Signed-off-by: Roy Golan <rgolan@redhat.com>

