### PR TITLE
Makefile: fix test-fast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,17 +91,16 @@ gosec: ## Run gosec locally
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: manifests generate fmt vet test-fast ## Run tests.
 
-integration-test:
-	make ginkgo
+integration-test: ginkgo
 	$(DOCKER) pull quay.io/project-flotta/edgedevice
 	$(GINKGO) -focus=$(FOCUS) run test/e2e
 
 TEST_PACKAGES := ./...
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test-fast:
+test-fast: ginkgo
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test  $(TEST_PACKAGES) -coverprofile cover.out --v -ginkgo.v -ginkgo.progress -ginkgo.skip e2e
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); $(GINKGO) --cover -outputdir=. -coverprofile=cover.out -v -progress -skip e2e $(TEST_PACKAGES)
 
 test-create-coverage:
 	sed -i '/mock_/d' cover.out
@@ -189,7 +188,9 @@ kustomize: ## Download kustomize locally if necessary.
 
 GINKGO = $(shell pwd)/bin/ginkgo
 ginkgo: ## Download ginkgo locally if necessary.
+ifeq (, $(shell which ginkgo))
 	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/ginkgo@v1.16.5)
+endif
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
When using ginkgo.skip the Focus tests didn't work as expected, so all
the tests should be run. That it's bad for debugging/fixing a flake.
This commit fixes that so using this `FIt` and `FContext` is working
correctly.

Example behaviour:

```
--> make test-fast TEST_PACKAGES=./internal/yggdrasil
mkdir -p /home/eloy/dev/upstream/project-flotta/k4e-operator/testbin
test -f /home/eloy/dev/upstream/project-flotta/k4e-operator/testbin/setup-envtest.sh || curl -sSLo /home/eloy/dev/upstream/project-flotta/k4e-operator/testbin/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
source /home/eloy/dev/upstream/project-flotta/k4e-operator/testbin/setup-envtest.sh; fetch_envtest_tools /home/eloy/dev/upstream/project-flotta/k4e-operator/testbin; setup_envtest_env /home/eloy/dev/upstream/project-flotta/k4e-operator/testbin; ginkgo ./internal/yggdrasil -coverprofile cover.out -v -progress -skip e2e
Using cached envtest tools from /home/eloy/dev/upstream/project-flotta/k4e-operator/testbin
setting up env vars
Running Suite: Yggdrasil Suite
==============================
Random Seed: 1646670839
Will run 1 of 53 specs

•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 53 Specs in 0.000 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 52 Skipped
PASS | FOCUSED

Ginkgo ran 1 suite in 1.782760455s
Test Suite Passed
Detected Programmatic Focus - setting exit status to 197
make: *** [Makefile:104: test-fast] Error 197
-->
```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>