### PR TITLE
Test: e2e gather always the logs for kind

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -37,10 +37,15 @@ jobs:
           # Run test
           make integration-test
 
-          # Export logs
+      # collect logs always just in case the test fails
+      - name: Collect all logs
+        if: always()
+        run: |
           kind export logs dist
+
       - name: Archive logs
         uses: actions/upload-artifact@v2
+        if: always()
         with:
           name: logs
           path: |


### PR DESCRIPTION
In this case we always gather the logs from kind even if the test fails
to be able to triage it.

Related-to: https://issues.redhat.com/browse/ECOPROJECT-649

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>