### PR TITLE
e2e: Fixes and gather logs

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -11,3 +11,14 @@ func TestE2e(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "E2e Suite")
 }
+
+// AfterFailed is a function that it's called on JustAfterEach to run a
+// function if the test fail. For example, retrieving logs.
+func AfterFailed(body func()) {
+	JustAfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			By("Running AfterFailed function")
+			body()
+		}
+	})
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -40,6 +40,10 @@ var _ = Describe("e2e", func() {
 
 	})
 
+	AfterFailed(func() {
+		device.DumpLogs()
+	})
+
 	AfterEach(func() {
 		_ = deployment.RemoveAll()
 		_ = device.Unregister()


### PR DESCRIPTION
Podman was not started when running the edgedevice, so the e2e tests
were failing because can't deploy to the edgedevice.

Also, I added a way to dump logs, ATM in the console, but in the next
days I'll evolve to a file, so logs can be attached to the end of the
job. For making it faster, logs are only retrieved when the test fails
and on the JustAfterEach function, so the device and containers, are
still in there.

Fix: https://issues.redhat.com/browse/ECOPROJECT-649

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>