### PR TITLE
Add indexers to flotta resources

### DIFF
--- a/controllers/edgedeployment_controller.go
+++ b/controllers/edgedeployment_controller.go
@@ -275,8 +275,7 @@ func (r *EdgeDeploymentReconciler) getMatchingEdgeDevices(ctx context.Context, e
 }
 
 func (r *EdgeDeploymentReconciler) getLabelledEdgeDevices(ctx context.Context, name, namespace string) ([]managementv1alpha1.EdgeDevice, error) {
-	selector := metav1.LabelSelector{MatchLabels: map[string]string{labels.WorkloadLabel(name): "true"}}
-	return r.EdgeDeviceRepository.ListForSelector(ctx, &selector, namespace)
+	return r.EdgeDeviceRepository.ListForWorkload(ctx, name, namespace)
 }
 
 func (r *EdgeDeploymentReconciler) executeConcurrent(ctx context.Context, f ConcurrentFunc, edgeDevices []managementv1alpha1.EdgeDevice) []error {

--- a/controllers/edgedevicelabels_controller.go
+++ b/controllers/edgedevicelabels_controller.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// EdgeDeviceReconciler reconciles a EdgeDevice object
+// EdgeDeviceLabelsReconciler reconciles a EdgeDevice object
 type EdgeDeviceLabelsReconciler struct {
 	EdgeDeviceRepository     edgedevice.Repository
 	EdgeDeploymentRepository edgedeployment.Repository

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -1,26 +1,28 @@
 package labels
 
-import "strings"
+import (
+	"strings"
+)
 
 const (
 	DeviceNameLabel     = "devicename"
 	DoesNotExistLabel   = "doesnotexist"
-	workloadLabelPrefix = "workload/"
-	selectorLabelPrefix = "selector/"
+	WorkloadLabelPrefix = "workload/"
+	SelectorLabelPrefix = "selector/"
 )
 
 func WorkloadLabel(workloadName string) string {
-	return workloadLabelPrefix + workloadName
+	return WorkloadLabelPrefix + workloadName
 }
 
 func IsWorkloadLabel(label string) bool {
-	return strings.HasPrefix(label, workloadLabelPrefix)
+	return strings.HasPrefix(label, WorkloadLabelPrefix)
 }
 
 func IsSelectorLabel(label string) bool {
-	return strings.HasPrefix(label, selectorLabelPrefix)
+	return strings.HasPrefix(label, SelectorLabelPrefix)
 }
 
 func CreateSelectorLabel(label string) string {
-	return selectorLabelPrefix + label
+	return SelectorLabelPrefix + label
 }

--- a/internal/repository/edgedeployment/edgedeployment.go
+++ b/internal/repository/edgedeployment/edgedeployment.go
@@ -2,11 +2,9 @@ package edgedeployment
 
 import (
 	"context"
-
 	_ "github.com/golang/mock/mockgen/model"
 	"github.com/project-flotta/flotta-operator/api/v1alpha1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
+	indexer "github.com/project-flotta/flotta-operator/internal/repository"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -58,12 +56,10 @@ func (r *CRRespository) RemoveFinalizer(ctx context.Context, edgeDeployment *v1a
 
 func (r *CRRespository) ListByLabel(ctx context.Context, labelName, labelValue string, namespace string) ([]v1alpha1.EdgeDeployment, error) {
 	edgeDeployments := v1alpha1.EdgeDeploymentList{}
-	requirement, err := labels.NewRequirement(labelName, selection.Equals, []string{labelValue})
-	if err != nil {
-		return nil, err
-	}
-	selector := labels.NewSelector().Add(*requirement)
-	err = r.client.List(ctx, &edgeDeployments, client.MatchingLabelsSelector{Selector: selector}, client.InNamespace(namespace))
+	err := r.client.List(ctx, &edgeDeployments,
+		client.MatchingFields{indexer.DeploymentByDeviceIndexKey: indexer.CreateDeploymentIndexKey(labelName, labelValue)},
+		client.InNamespace(namespace),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/edgedevice/mock_edgedevice.go
+++ b/internal/repository/edgedevice/mock_edgedevice.go
@@ -66,6 +66,21 @@ func (mr *MockRepositoryMockRecorder) ListForSelector(arg0, arg1, arg2 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListForSelector", reflect.TypeOf((*MockRepository)(nil).ListForSelector), arg0, arg1, arg2)
 }
 
+// ListForWorkload mocks base method.
+func (m *MockRepository) ListForWorkload(arg0 context.Context, arg1, arg2 string) ([]v1alpha1.EdgeDevice, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListForWorkload", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]v1alpha1.EdgeDevice)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListForWorkload indicates an expected call of ListForWorkload.
+func (mr *MockRepositoryMockRecorder) ListForWorkload(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListForWorkload", reflect.TypeOf((*MockRepository)(nil).ListForWorkload), arg0, arg1, arg2)
+}
+
 // Patch mocks base method.
 func (m *MockRepository) Patch(arg0 context.Context, arg1, arg2 *v1alpha1.EdgeDevice) error {
 	m.ctrl.T.Helper()

--- a/internal/repository/indexer.go
+++ b/internal/repository/indexer.go
@@ -1,0 +1,56 @@
+package indexer
+
+import (
+	"strings"
+
+	"github.com/project-flotta/flotta-operator/api/v1alpha1"
+	"github.com/project-flotta/flotta-operator/internal/labels"
+	flottalabels "github.com/project-flotta/flotta-operator/internal/labels"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// DeploymentByDeviceIndexKey is the name of the indexer for deployments by device
+	DeploymentByDeviceIndexKey = "deployment-by-device"
+
+	// DeviceByWorkloadIndexKey is the key of the indexer for devices by workload
+	DeviceByWorkloadIndexKey = "device-by-workload"
+)
+
+func DeploymentByDeviceIndexFunc(obj ctrlruntimeclient.Object) []string {
+	deployment := obj.(*v1alpha1.EdgeDeployment)
+	var keys []string
+	for name, value := range deployment.Labels {
+		if flottalabels.IsSelectorLabel(name) {
+			keys = append(keys, CreateDeploymentIndexKey(name, value))
+		}
+	}
+	return keys
+}
+
+func DeviceByWorkloadIndexFunc(obj ctrlruntimeclient.Object) []string {
+	device := obj.(*v1alpha1.EdgeDevice)
+	var keys []string
+	// iterate over labels map and return a list of workloads as keys
+	for name := range device.Labels {
+		if flottalabels.IsWorkloadLabel(name) {
+			keys = append(keys, CreateDeviceIndexKey(name))
+		}
+	}
+	return keys
+}
+
+// CreateDeviceIndexKey creates a key for the device index which is basically the workload name
+func CreateDeviceIndexKey(label string) string {
+	return strings.TrimPrefix(label, labels.WorkloadLabelPrefix)
+}
+
+// CreateDeploymentIndexKey creates a key for the deployment index
+// The key is of the form: device or label
+func CreateDeploymentIndexKey(label, value string) string {
+	suffix := strings.TrimPrefix(label, labels.SelectorLabelPrefix)
+	if suffix == labels.DeviceNameLabel {
+		return value
+	}
+	return suffix
+}

--- a/internal/repository/indexer_suite_test.go
+++ b/internal/repository/indexer_suite_test.go
@@ -1,0 +1,13 @@
+package indexer_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Indexers Spec")
+}

--- a/internal/repository/indexer_test.go
+++ b/internal/repository/indexer_test.go
@@ -1,0 +1,50 @@
+package indexer_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	managementv1alpha1 "github.com/project-flotta/flotta-operator/api/v1alpha1"
+	flottalabels "github.com/project-flotta/flotta-operator/internal/labels"
+	indexer "github.com/project-flotta/flotta-operator/internal/repository"
+)
+
+var _ = Describe("Index functions", func() {
+
+	Context("Index func of edge deployment", func() {
+		It("Creates keys by selector labels only", func() {
+			// given
+			deployment := managementv1alpha1.EdgeDeployment{}
+			deployment.Labels = map[string]string{
+				"foo":                                    "bar",
+				flottalabels.SelectorLabelPrefix + "abc": "123",
+				flottalabels.SelectorLabelPrefix + flottalabels.DeviceNameLabel: "xyz",
+			}
+
+			// when
+			keys := indexer.DeploymentByDeviceIndexFunc(&deployment)
+
+			// then
+			Expect(keys).To(HaveLen(2))
+			Expect(keys).Should(ConsistOf("abc", "xyz"))
+		})
+	})
+
+	Context("Index func of edge device", func() {
+		It("Creates keys by workload labels only", func() {
+			// given
+			edge := managementv1alpha1.EdgeDevice{}
+			edge.Labels = map[string]string{
+				"foo":                                    "bar",
+				flottalabels.WorkloadLabelPrefix + "abc": "123",
+			}
+
+			// when
+			keys := indexer.DeviceByWorkloadIndexFunc(&edge)
+
+			// then
+			Expect(keys).To(HaveLen(1))
+			Expect(keys[0]).To(Equal("abc"))
+		})
+	})
+})


### PR DESCRIPTION
Adding indexers on flotta's CR cache.
In addition, added namespace scope for edgedeployment.ListByLabel
which is the most CPU consuming function.

Signed-off-by: Moti Asayag <masayag@redhat.com>