### PR TITLE
Specify namespace in List call

### DIFF
--- a/controllers/edgedevicelabels_controller.go
+++ b/controllers/edgedevicelabels_controller.go
@@ -86,7 +86,7 @@ func (r *EdgeDeviceLabelsReconciler) updateDeployments(ctx context.Context, devi
 	selectedDeployments := map[string]bool{} // each deployment we read is here. the value is true if the deployment matches the device
 
 	for selectorLabel, labelValue := range selectorLabels {
-		deployments, err := r.EdgeDeploymentRepository.ListByLabel(ctx, selectorLabel, labelValue)
+		deployments, err := r.EdgeDeploymentRepository.ListByLabel(ctx, selectorLabel, labelValue, device.Namespace)
 		if err != nil {
 			return err
 		}

--- a/controllers/edgedevicelabels_controller_test.go
+++ b/controllers/edgedevicelabels_controller_test.go
@@ -23,6 +23,9 @@ import (
 )
 
 var _ = Describe("EdgeDeviceLabels controller/Reconcile", func() {
+	const (
+		namespace string = "test"
+	)
 	var (
 		mockCtrl                   *gomock.Controller
 		deployRepoMock             *edgedeployment.MockRepository
@@ -31,7 +34,7 @@ var _ = Describe("EdgeDeviceLabels controller/Reconcile", func() {
 		req                        = ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      "test",
-				Namespace: "test",
+				Namespace: namespace,
 			},
 		}
 		device *v1alpha1.EdgeDevice
@@ -41,7 +44,7 @@ var _ = Describe("EdgeDeviceLabels controller/Reconcile", func() {
 		return &v1alpha1.EdgeDeployment{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      name,
-				Namespace: "test",
+				Namespace: namespace,
 			},
 			Spec: v1alpha1.EdgeDeploymentSpec{
 				Type: "pod",
@@ -62,7 +65,7 @@ var _ = Describe("EdgeDeviceLabels controller/Reconcile", func() {
 		device = &v1alpha1.EdgeDevice{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "test",
-				Namespace: "test",
+				Namespace: namespace,
 			},
 			Spec: v1alpha1.EdgeDeviceSpec{
 				RequestTime: &v1.Time{},
@@ -130,7 +133,7 @@ var _ = Describe("EdgeDeviceLabels controller/Reconcile", func() {
 			Return(device, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any()).
+			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any(), namespace).
 			Return(nil, fmt.Errorf("test")).
 			Times(1)
 
@@ -159,7 +162,7 @@ var _ = Describe("EdgeDeviceLabels controller/Reconcile", func() {
 			Return(device, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any()).
+			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any(), namespace).
 			Return(deployments, nil).
 			Times(1)
 
@@ -178,7 +181,7 @@ var _ = Describe("EdgeDeviceLabels controller/Reconcile", func() {
 			Return(device, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any()).
+			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any(), namespace).
 			Return(nil, nil).
 			Times(2)
 
@@ -217,11 +220,11 @@ var _ = Describe("EdgeDeviceLabels controller/Reconcile", func() {
 			Return(device, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), labels.CreateSelectorLabel(labels.DeviceNameLabel), gomock.Any()).
+			ListByLabel(gomock.Any(), labels.CreateSelectorLabel(labels.DeviceNameLabel), gomock.Any(), namespace).
 			Return(nil, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any()).
+			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any(), namespace).
 			Return(deploymentList, nil).
 			Times(2)
 		edgeDeviceRepoMock.EXPECT().
@@ -270,11 +273,11 @@ var _ = Describe("EdgeDeviceLabels controller/Reconcile", func() {
 			Return(device, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), labels.CreateSelectorLabel(labels.DeviceNameLabel), gomock.Any()).
+			ListByLabel(gomock.Any(), labels.CreateSelectorLabel(labels.DeviceNameLabel), gomock.Any(), namespace).
 			Return(deploymentList, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any()).
+			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any(), namespace).
 			Return(nil, nil).
 			Times(1)
 
@@ -335,23 +338,23 @@ var _ = Describe("EdgeDeviceLabels controller/Reconcile", func() {
 			Return(device, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), labels.CreateSelectorLabel(labels.DeviceNameLabel), gomock.Any()).
+			ListByLabel(gomock.Any(), labels.CreateSelectorLabel(labels.DeviceNameLabel), gomock.Any(), namespace).
 			Return([]v1alpha1.EdgeDeployment{*deployment1}, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), labels.CreateSelectorLabel("label1"), gomock.Any()).
+			ListByLabel(gomock.Any(), labels.CreateSelectorLabel("label1"), gomock.Any(), namespace).
 			Return([]v1alpha1.EdgeDeployment{*deployment2}, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), labels.CreateSelectorLabel(labels.DoesNotExistLabel), gomock.Any()).
+			ListByLabel(gomock.Any(), labels.CreateSelectorLabel(labels.DoesNotExistLabel), gomock.Any(), namespace).
 			Return([]v1alpha1.EdgeDeployment{*deployment3}, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), labels.CreateSelectorLabel("exist"), gomock.Any()).
+			ListByLabel(gomock.Any(), labels.CreateSelectorLabel("exist"), gomock.Any(), namespace).
 			Return([]v1alpha1.EdgeDeployment{*deployment4}, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), labels.CreateSelectorLabel("label2"), gomock.Any()).
+			ListByLabel(gomock.Any(), labels.CreateSelectorLabel("label2"), gomock.Any(), namespace).
 			Return([]v1alpha1.EdgeDeployment{*deployment5}, nil).
 			Times(1)
 		edgeDeviceRepoMock.EXPECT().
@@ -419,15 +422,15 @@ var _ = Describe("EdgeDeviceLabels controller/Reconcile", func() {
 			Return(device, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), labels.CreateSelectorLabel("toadd"), gomock.Any()).
+			ListByLabel(gomock.Any(), labels.CreateSelectorLabel("toadd"), gomock.Any(), namespace).
 			Return([]v1alpha1.EdgeDeployment{*deploymentToAdd}, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), labels.CreateSelectorLabel("tokeep"), gomock.Any()).
+			ListByLabel(gomock.Any(), labels.CreateSelectorLabel("tokeep"), gomock.Any(), namespace).
 			Return([]v1alpha1.EdgeDeployment{*deploymentToKeep}, nil).
 			Times(1)
 		deployRepoMock.EXPECT().
-			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any()).
+			ListByLabel(gomock.Any(), gomock.Any(), gomock.Any(), namespace).
 			Return(nil, nil).
 			Times(2)
 

--- a/internal/repository/edgedeployment/edgedeployment.go
+++ b/internal/repository/edgedeployment/edgedeployment.go
@@ -15,7 +15,7 @@ type Repository interface {
 	Read(ctx context.Context, name string, namespace string) (*v1alpha1.EdgeDeployment, error)
 	Patch(ctx context.Context, old, new *v1alpha1.EdgeDeployment) error
 	RemoveFinalizer(ctx context.Context, edgeDeployment *v1alpha1.EdgeDeployment, finalizer string) error
-	ListByLabel(ctx context.Context, labelName, labelValue string) ([]v1alpha1.EdgeDeployment, error)
+	ListByLabel(ctx context.Context, labelName, labelValue string, namespace string) ([]v1alpha1.EdgeDeployment, error)
 }
 
 type CRRespository struct {
@@ -56,14 +56,14 @@ func (r *CRRespository) RemoveFinalizer(ctx context.Context, edgeDeployment *v1a
 	return nil
 }
 
-func (r *CRRespository) ListByLabel(ctx context.Context, labelName, labelValue string) ([]v1alpha1.EdgeDeployment, error) {
+func (r *CRRespository) ListByLabel(ctx context.Context, labelName, labelValue string, namespace string) ([]v1alpha1.EdgeDeployment, error) {
 	edgeDeployments := v1alpha1.EdgeDeploymentList{}
 	requirement, err := labels.NewRequirement(labelName, selection.Equals, []string{labelValue})
 	if err != nil {
 		return nil, err
 	}
 	selector := labels.NewSelector().Add(*requirement)
-	err = r.client.List(ctx, &edgeDeployments, client.MatchingLabelsSelector{Selector: selector})
+	err = r.client.List(ctx, &edgeDeployments, client.MatchingLabelsSelector{Selector: selector}, client.InNamespace(namespace))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/edgedeployment/mock_edgedeployment.go
+++ b/internal/repository/edgedeployment/mock_edgedeployment.go
@@ -36,18 +36,18 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 }
 
 // ListByLabel mocks base method.
-func (m *MockRepository) ListByLabel(arg0 context.Context, arg1, arg2 string) ([]v1alpha1.EdgeDeployment, error) {
+func (m *MockRepository) ListByLabel(arg0 context.Context, arg1, arg2, arg3 string) ([]v1alpha1.EdgeDeployment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByLabel", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ListByLabel", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]v1alpha1.EdgeDeployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListByLabel indicates an expected call of ListByLabel.
-func (mr *MockRepositoryMockRecorder) ListByLabel(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) ListByLabel(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByLabel", reflect.TypeOf((*MockRepository)(nil).ListByLabel), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByLabel", reflect.TypeOf((*MockRepository)(nil).ListByLabel), arg0, arg1, arg2, arg3)
 }
 
 // Patch mocks base method.


### PR DESCRIPTION
Namespace should be specified in order to narrow the search only for
deployments in the same namespace as the device.

Signed-off-by: Moti Asayag <masayag@redhat.com>