### PR TITLE
Propagate deployment labels to workload

### DIFF
--- a/api/v1alpha1/edgedeployment_webhook_test.go
+++ b/api/v1alpha1/edgedeployment_webhook_test.go
@@ -204,6 +204,5 @@ var _ = Describe("EdgeDeployment Webhook", func() {
 			Expect(err).Should(MatchError("name collisions for containers within the same pod spec are not supported.\n" +
 				"container name: 'container' has been reused"))
 		})
-
 	})
 })

--- a/docs/design/http_api_swagger.md
+++ b/docs/design/http_api_swagger.md
@@ -981,11 +981,12 @@ Status: Internal Server Error
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| configmaps | [ConfigmapList](#configmap-list)| `ConfigmapList` |  | |  |  |
-| data | [DataConfiguration](#data-configuration)| `DataConfiguration` |  | |  |  |
-| imageRegistries | [ImageRegistries](#image-registries)| `ImageRegistries` |  | |  |  |
+| configmaps | [ConfigmapList](#configmap-list)| `ConfigmapList` |  | | List of configmaps used by the workload |  |
+| data | [DataConfiguration](#data-configuration)| `DataConfiguration` |  | | Configuration for data transfer |  |
+| imageRegistries | [ImageRegistries](#image-registries)| `ImageRegistries` |  | | Image registries configuration |  |
+| labels | map of string| `map[string]string` |  | | Workload labels | Workload labels |
 | log_collection | string| `string` |  | | Log collection target for this workload |  |
-| metrics | [Metrics](#metrics)| `Metrics` |  | |  |  |
+| metrics | [Metrics](#metrics)| `Metrics` |  | | Metrics endpoint configuration |  |
 | name | string| `string` |  | | Name of the workload |  |
 | namespace | string| `string` |  | | Namespace of the workload |  |
 | specification | string| `string` |  | |  |  |

--- a/docs/user-guide/autoupdate.md
+++ b/docs/user-guide/autoupdate.md
@@ -1,0 +1,35 @@
+# Podman auto-update
+
+Auto update containers according to their auto-update policy.
+
+Auto-update looks up containers with a specified `io.containers.autoupdate` label. This label is set by the `flotta-operator`.
+Flotta-operator looks up labels on `EdgeDeployments` CR prefixed by `podman/` string. If such label is found it's propageted to
+the podman pod and containers.
+
+If  the  label  is  present  and set to registry, Podman reaches out to the corresponding registry to check if the image has been updated. The label image is an alternative to registry maintained for
+backwards compatibility.  An image is considered updated if the digest in the local storage is different than the one of the remote image.  If an image must be  updated,  Podman  pulls  it  down  and
+restarts the systemd unit executing the container.
+
+If `ImageRegistries.AuthFileSecret` is defined, Podman reaches out to the corresponding authfile when pulling images.
+
+Edgedevice start the `podman-auto-update.timer` which is responsible for executing the `podman-auto-update.service`. This unit is triggered daily.
+
+To create a Edgedeployment with auto-update feature enabled define following label:
+```yaml
+apiVersion: management.project-flotta.io/v1alpha1
+kind: EdgeDeployment
+metadata:
+  name: nginx
+  labels:
+    podman/io.containers.autoupdate: registry
+spec:
+  deviceSelector:
+    matchLabels:
+      device: local
+  type: pod
+  pod:
+    spec:
+      containers:
+        - name: nginx
+          image: quay.io/bitnami/nginx:1.20
+```

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -26,3 +26,14 @@ func IsSelectorLabel(label string) bool {
 func CreateSelectorLabel(label string) string {
 	return SelectorLabelPrefix + label
 }
+
+// GetPodmanLabels filter all the labels of the EdgeDeployment CR starting with prefix "podman/"
+func GetPodmanLabels(deploymentLabels map[string]string) map[string]string {
+	labels := map[string]string{}
+	for key, value := range deploymentLabels {
+		if strings.HasPrefix(key, "podman/") {
+			labels[key[7:]] = value
+		}
+	}
+	return labels
+}

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -8,6 +8,7 @@ import (
 	"github.com/project-flotta/flotta-operator/internal/configmaps"
 	"github.com/project-flotta/flotta-operator/internal/devicemetrics"
 	"github.com/project-flotta/flotta-operator/internal/heartbeat"
+	"github.com/project-flotta/flotta-operator/internal/labels"
 	"github.com/project-flotta/flotta-operator/pkg/mtls"
 
 	"net/http"
@@ -492,6 +493,7 @@ func (h *Handler) toWorkloadList(ctx context.Context, logger logr.Logger, deploy
 		workload := models.Workload{
 			Name:          deployment.Name,
 			Namespace:     deployment.Namespace,
+			Labels:        labels.GetPodmanLabels(deployment.Labels),
 			Specification: string(podSpec),
 			Data:          data,
 			LogCollection: spec.LogCollection,

--- a/models/workload.go
+++ b/models/workload.go
@@ -25,6 +25,9 @@ type Workload struct {
 	// image registries
 	ImageRegistries *ImageRegistries `json:"imageRegistries,omitempty"`
 
+	// Workload labels
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// Log collection target for this workload
 	LogCollection string `json:"log_collection,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -938,6 +938,13 @@ func init() {
         "imageRegistries": {
           "$ref": "#/definitions/image-registries"
         },
+        "labels": {
+          "description": "Workload labels",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "log_collection": {
           "description": "Log collection target for this workload",
           "type": "string"
@@ -1937,6 +1944,13 @@ func init() {
         },
         "imageRegistries": {
           "$ref": "#/definitions/image-registries"
+        },
+        "labels": {
+          "description": "Workload labels",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "log_collection": {
           "description": "Log collection target for this workload",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -320,6 +320,11 @@ definitions:
       namespace:
         description: Namespace of the workload
         type: string
+      labels:
+        type: object
+        description: Workload labels
+        additionalProperties:
+          type: string
       specification:
         type: string
       data:


### PR DESCRIPTION
This PR add labels propagation from the edgedeployment CR to the
workload swagger specification.

The labels will be used to create the podman pod and so the pod could be
customized by specifing labels in the edgedeployment CR.

Issue: https://issues.redhat.com/browse/ECOPROJECT-281

For example if user want to create a pod with containers that has auto-update policy, he would create the edgedeployment as follows:

```yaml
apiVersion: management.project-flotta.io/v1alpha1
kind: EdgeDeployment
metadata:
  name: nginx
  labels:
    podman/io.containers.autoupdate: registry
spec:
  type: pod
  pod:
    spec:
      containers:
        - name: nginx
          image: quay.io/bitnami/nginx:latest
```

This will create a pod with label `io.containers.autoupdate: registry` and also all containers in the pod with such a label.