### PR TITLE
Pass deployment namespace as workload namespace

### DIFF
--- a/docs/design/http_api_swagger.md
+++ b/docs/design/http_api_swagger.md
@@ -932,6 +932,7 @@ Status: Internal Server Error
 | log_collection | string| `string` |  | | Log collection target for this workload |  |
 | metrics | [Metrics](#metrics)| `Metrics` |  | | Metrics endpoint configuration |  |
 | name | string| `string` |  | | Name of the workload |  |
+| namespace | string| `string` |  | | Namespace of the workload |  |
 | specification | string| `string` |  | |  |  |
 
 

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -448,6 +448,7 @@ func (h *Handler) toWorkloadList(ctx context.Context, logger logr.Logger, deploy
 
 		workload := models.Workload{
 			Name:          deployment.Name,
+			Namespace:     deployment.Namespace,
 			Specification: string(podSpec),
 			Data:          data,
 			LogCollection: spec.LogCollection,

--- a/internal/yggdrasil/yggdrasil_integration_test.go
+++ b/internal/yggdrasil/yggdrasil_integration_test.go
@@ -491,6 +491,7 @@ var _ = Describe("Yggdrasil", func() {
 			Expect(config.Workloads).To(HaveLen(1))
 			workload := config.Workloads[0]
 			Expect(workload.Name).To(Equal("workload1"))
+			Expect(workload.Namespace).To(Equal("default"))
 			Expect(workload.ImageRegistries).To(BeNil())
 		})
 

--- a/models/workload.go
+++ b/models/workload.go
@@ -34,6 +34,9 @@ type Workload struct {
 	// Name of the workload
 	Name string `json:"name,omitempty"`
 
+	// Namespace of the workload
+	Namespace string `json:"namespace,omitempty"`
+
 	// specification
 	Specification string `json:"specification,omitempty"`
 }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -941,6 +941,10 @@ func init() {
           "description": "Name of the workload",
           "type": "string"
         },
+        "namespace": {
+          "description": "Namespace of the workload",
+          "type": "string"
+        },
         "specification": {
           "type": "string"
         }
@@ -1922,6 +1926,10 @@ func init() {
         },
         "name": {
           "description": "Name of the workload",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the workload",
           "type": "string"
         },
         "specification": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -307,6 +307,9 @@ definitions:
       name:
         type: string
         description: Name of the workload
+      namespace:
+        type: string
+        description: Namespace of the workload
       specification:
         type: string
       data:


### PR DESCRIPTION
This commit add a new parameter namespace to workload model type, which
define the namespace of the deployment and should be used to distinguish
the workload on device-worker side.

Signed-off-by: Ondra Machacek <omachace@redhat.com>