### PR TITLE
e2e: added project-flotta.io host on device creation

### DIFF
--- a/test/e2e/edgedevice_test.go
+++ b/test/e2e/edgedevice_test.go
@@ -212,7 +212,7 @@ func (e *edgeDeviceDocker) waitForDevice(cond func() bool) error {
 
 func (e *edgeDeviceDocker) Register() error {
 	ctx := context.Background()
-	resp, err := e.cli.ContainerCreate(ctx, &container.Config{Image: EdgeDeviceImage}, &container.HostConfig{Privileged: true}, nil, nil, e.name)
+	resp, err := e.cli.ContainerCreate(ctx, &container.Config{Image: EdgeDeviceImage}, &container.HostConfig{Privileged: true, ExtraHosts: []string{"project-flotta.io:172.17.0.1"}}, nil, nil, e.name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
To be able to do the TLS handshake correctly on yggdrasil.

Fix https://issues.redhat.com/browse/ECOPROJECT-399
Related-to: https://github.com/project-flotta/flotta-device-worker/pull/112

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>