### PR TITLE
API: Authorization on API endpoints.

### DIFF
--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -363,6 +363,14 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 
 		_, err = h.deviceRepository.Read(ctx, deviceID, h.initialNamespace)
 		if err == nil {
+
+			if !IsOwnDevice(ctx, deviceID) {
+				// At this moment, the registration certificate it's no longer valid,
+				// because the CR is already created, and need to be a device
+				// certificate.
+				return operations.NewPostDataMessageForDeviceForbidden()
+			}
+
 			// @TODO remove this IF when MTLS is finished
 			if registrationInfo.CertificateRequest != "" {
 				cert, err := h.mtlsConfig.SignCSR(registrationInfo.CertificateRequest, deviceID)

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -11,7 +11,6 @@ import (
 	"github.com/project-flotta/flotta-operator/pkg/mtls"
 
 	"net/http"
-	"net/url"
 	"strings"
 
 	"time"
@@ -32,6 +31,7 @@ import (
 	"github.com/project-flotta/flotta-operator/internal/storage"
 	"github.com/project-flotta/flotta-operator/internal/utils"
 	"github.com/project-flotta/flotta-operator/models"
+	apioperations "github.com/project-flotta/flotta-operator/restapi/operations"
 	"github.com/project-flotta/flotta-operator/restapi/operations/yggdrasil"
 	operations "github.com/project-flotta/flotta-operator/restapi/operations/yggdrasil"
 	corev1 "k8s.io/api/core/v1"
@@ -43,10 +43,12 @@ import (
 )
 
 const (
-	YggdrasilConnectionFinalizer = "yggdrasil-connection-finalizer"
-	YggdrasilWorkloadFinalizer   = "yggdrasil-workload-finalizer"
-	YggdrasilRegisterAuth        = 1
-	YggdrasilCompleteAuth        = 0
+	YggdrasilConnectionFinalizer                         = "yggdrasil-connection-finalizer"
+	YggdrasilWorkloadFinalizer                           = "yggdrasil-workload-finalizer"
+	YggdrasilRegisterAuth                                = 1
+	YggdrasilCompleteAuth                                = 0
+	AuthzKey                         mtls.RequestAuthKey = "APIAuthzkey"
+	YggrasilAPIRegistrationOperation                     = "PostDataMessageForDevice"
 )
 
 var (
@@ -94,26 +96,45 @@ func NewYggdrasilHandler(deviceRepository edgedevice.Repository, deploymentRepos
 	}
 }
 
-func isRegistrationURL(url *url.URL) bool {
-	parts := strings.Split(url.Path, "/")
-	if len(parts) == 0 {
+func IsOwnDevice(ctx context.Context, deviceID string) bool {
+	if deviceID == "" {
 		return false
 	}
 
-	last := parts[len(parts)-1]
-	return last == "registration"
+	val, ok := ctx.Value(AuthzKey).(string)
+	if !ok {
+		return false
+	}
+	return val == strings.ToLower(deviceID)
 }
 
-func (h *Handler) GetAuthType(r *http.Request) int {
+// GetAuthType returns the kind of the authz that need to happen on the API call, the options are:
+// YggdrasilCompleteAuth: need to be a valid client certificate and not expired.
+// YggdrasilRegisterAuth: it is only valid for registering action.
+func (h *Handler) GetAuthType(r *http.Request, api *apioperations.FlottaManagementAPI) int {
 	res := YggdrasilCompleteAuth
-	if isRegistrationURL(r.URL) {
-		res = YggdrasilRegisterAuth
+	if api == nil {
+		return res
+	}
+
+	route, _, matches := api.Context().RouteInfo(r)
+	if !matches {
+		return res
+	}
+
+	if route != nil && route.Operation != nil {
+		if route.Operation.ID == YggrasilAPIRegistrationOperation {
+			return YggdrasilRegisterAuth
+		}
 	}
 	return res
 }
 
 func (h *Handler) GetControlMessageForDevice(ctx context.Context, params yggdrasil.GetControlMessageForDeviceParams) middleware.Responder {
 	deviceID := params.DeviceID
+	if !IsOwnDevice(ctx, deviceID) {
+		return operations.NewGetControlMessageForDeviceForbidden()
+	}
 	logger := log.FromContext(ctx, "DeviceID", deviceID)
 	edgeDevice, err := h.deviceRepository.Read(ctx, deviceID, h.initialNamespace)
 	if err != nil {
@@ -141,6 +162,9 @@ func (h *Handler) GetControlMessageForDevice(ctx context.Context, params yggdras
 
 func (h *Handler) GetDataMessageForDevice(ctx context.Context, params yggdrasil.GetDataMessageForDeviceParams) middleware.Responder {
 	deviceID := params.DeviceID
+	if !IsOwnDevice(ctx, deviceID) {
+		return operations.NewGetDataMessageForDeviceForbidden()
+	}
 	logger := log.FromContext(ctx, "DeviceID", deviceID)
 	edgeDevice, err := h.deviceRepository.Read(ctx, deviceID, h.initialNamespace)
 	if err != nil {
@@ -284,6 +308,10 @@ func (h *Handler) getDeviceMetricsConfiguration(ctx context.Context, edgeDevice 
 }
 
 func (h *Handler) PostControlMessageForDevice(ctx context.Context, params yggdrasil.PostControlMessageForDeviceParams) middleware.Responder {
+	deviceID := params.DeviceID
+	if !IsOwnDevice(ctx, deviceID) {
+		return operations.NewPostDataMessageForDeviceForbidden()
+	}
 	return operations.NewPostControlMessageForDeviceOK()
 }
 
@@ -291,6 +319,11 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 	deviceID := params.DeviceID
 	logger := log.FromContext(ctx, "DeviceID", deviceID)
 	msg := params.Message
+	if msg.Directive != "registration" {
+		if !IsOwnDevice(ctx, deviceID) {
+			return operations.NewPostDataMessageForDeviceForbidden()
+		}
+	}
 	switch msg.Directive {
 	case "heartbeat":
 		hb := models.Heartbeat{}

--- a/internal/yggdrasil/yggdrasil_integration_test.go
+++ b/internal/yggdrasil/yggdrasil_integration_test.go
@@ -2215,6 +2215,31 @@ var _ = Describe("Yggdrasil", func() {
 					Expect(data.Payload.Content).NotTo(BeNil())
 				})
 
+				It("Device is already register, and send a CSR to renew with invalid cert", func() {
+					// given
+					edgeDeviceRepoMock.EXPECT().
+						Read(gomock.Any(), deviceName, testNamespace).
+						Return(device, nil).
+						Times(1)
+
+					params := api.PostDataMessageForDeviceParams{
+						DeviceID: deviceName,
+						Message: &models.Message{
+							Directive: directiveName,
+							Content: models.RegistrationInfo{
+								CertificateRequest: string(givenCert),
+								Hardware:           nil,
+							},
+						},
+					}
+
+					// when
+					res := handler.PostDataMessageForDevice(context.TODO(), params)
+
+					// then
+					Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceForbidden{}))
+				})
+
 				It("Device is not registered, and send a valid CSR", func() {
 
 					// given

--- a/internal/yggdrasil/yggdrasil_integration_test.go
+++ b/internal/yggdrasil/yggdrasil_integration_test.go
@@ -51,10 +51,11 @@ const (
 	YggdrasilWorkloadFinalizer   = "yggdrasil-workload-finalizer"
 	YggdrasilConnectionFinalizer = "yggdrasil-connection-finalizer"
 
-	MessageTypeConnectionStatus string = "connection-status"
-	MessageTypeCommand          string = "command"
-	MessageTypeEvent            string = "event"
-	MessageTypeData             string = "data"
+	MessageTypeConnectionStatus string              = "connection-status"
+	MessageTypeCommand          string              = "command"
+	MessageTypeEvent            string              = "event"
+	MessageTypeData             string              = "data"
+	AuthzKey                    mtls.RequestAuthKey = "APIAuthzkey" // the same as yggdrasil one, but important if got changed
 )
 
 var _ = Describe("Yggdrasil", func() {
@@ -134,7 +135,26 @@ var _ = Describe("Yggdrasil", func() {
 			params = api.GetControlMessageForDeviceParams{
 				DeviceID: "foo",
 			}
+			deviceCtx = context.WithValue(context.TODO(), AuthzKey, "foo")
 		)
+
+		It("cannot retrieve another device", func() {
+			ctx := context.WithValue(context.TODO(), AuthzKey, "bar")
+
+			// when
+			res := handler.GetControlMessageForDevice(ctx, params)
+
+			// then
+			Expect(res).To(Equal(operations.NewGetControlMessageForDeviceForbidden()))
+		})
+
+		It("cannot retrieve device with empty context", func() {
+			// when
+			res := handler.GetControlMessageForDevice(context.TODO(), params)
+
+			// then
+			Expect(res).To(Equal(operations.NewGetControlMessageForDeviceForbidden()))
+		})
 
 		It("Can retrieve message correctly", func() {
 			// given
@@ -145,7 +165,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetControlMessageForDevice(context.TODO(), params)
+			res := handler.GetControlMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(Equal(operations.NewGetControlMessageForDeviceOK()))
@@ -159,7 +179,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetControlMessageForDevice(context.TODO(), params)
+			res := handler.GetControlMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(Equal(operations.NewGetControlMessageForDeviceNotFound()))
@@ -173,7 +193,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetControlMessageForDevice(context.TODO(), params)
+			res := handler.GetControlMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(Equal(operations.NewGetControlMessageForDeviceInternalServerError()))
@@ -190,7 +210,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetControlMessageForDevice(context.TODO(), params)
+			res := handler.GetControlMessageForDevice(deviceCtx, params)
 			data := res.(*api.GetControlMessageForDeviceOK)
 
 			// then
@@ -208,7 +228,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetControlMessageForDevice(context.TODO(), params)
+			res := handler.GetControlMessageForDevice(deviceCtx, params)
 			// then
 			Expect(res).To(Equal(operations.NewGetControlMessageForDeviceOK()))
 		})
@@ -234,7 +254,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetControlMessageForDevice(context.TODO(), params)
+			res := handler.GetControlMessageForDevice(deviceCtx, params)
 			data := res.(*api.GetControlMessageForDeviceOK)
 
 			// then
@@ -258,7 +278,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetControlMessageForDevice(context.TODO(), params)
+			res := handler.GetControlMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(Equal(operations.NewGetControlMessageForDeviceInternalServerError()))
@@ -272,6 +292,7 @@ var _ = Describe("Yggdrasil", func() {
 			params = api.GetDataMessageForDeviceParams{
 				DeviceID: "foo",
 			}
+			deviceCtx = context.WithValue(context.TODO(), AuthzKey, "foo")
 		)
 
 		validateAndGetDeviceConfig := func(res middleware.Responder) models.DeviceConfigurationMessage {
@@ -286,6 +307,24 @@ var _ = Describe("Yggdrasil", func() {
 			return content
 		}
 
+		It("Trying to access with not owning device", func() {
+			// given
+			ctx := context.WithValue(context.TODO(), AuthzKey, "bar")
+			// when
+			res := handler.GetDataMessageForDevice(ctx, params)
+
+			// then
+			Expect(res).To(Equal(operations.NewGetDataMessageForDeviceForbidden()))
+		})
+
+		It("Trying to access no context device", func() {
+			// when
+			res := handler.GetDataMessageForDevice(context.TODO(), params)
+
+			// then
+			Expect(res).To(Equal(operations.NewGetDataMessageForDeviceForbidden()))
+		})
+
 		It("Device is not in repo", func() {
 			// given
 			edgeDeviceRepoMock.EXPECT().
@@ -294,7 +333,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(Equal(operations.NewGetDataMessageForDeviceNotFound()))
@@ -308,7 +347,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(Equal(operations.NewGetDataMessageForDeviceInternalServerError()))
@@ -325,7 +364,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -346,7 +385,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -372,7 +411,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(Equal(operations.NewGetDataMessageForDeviceInternalServerError()))
@@ -395,7 +434,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -419,7 +458,7 @@ var _ = Describe("Yggdrasil", func() {
 				Return(nil, fmt.Errorf("Failed"))
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(Equal(operations.NewGetDataMessageForDeviceInternalServerError()))
@@ -441,7 +480,7 @@ var _ = Describe("Yggdrasil", func() {
 				Return(nil, errorNotFound)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -481,7 +520,7 @@ var _ = Describe("Yggdrasil", func() {
 				Return(deploymentData, nil)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -499,6 +538,7 @@ var _ = Describe("Yggdrasil", func() {
 
 			var (
 				deviceName string = "foo"
+				deviceCtx         = context.WithValue(context.TODO(), AuthzKey, deviceName)
 				device     *v1alpha1.EdgeDevice
 				deploy     *v1alpha1.EdgeDeployment
 			)
@@ -558,7 +598,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 				deploy.Spec.LogCollection = "syslog"
 				// when
-				res := handler.GetDataMessageForDevice(context.TODO(), params)
+				res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -606,7 +646,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 				deploy.Spec.LogCollection = "syslog"
 				// when
-				res := handler.GetDataMessageForDevice(context.TODO(), params)
+				res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 				// then
 
@@ -632,7 +672,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 				deploy.Spec.LogCollection = "syslog"
 				// when
-				res := handler.GetDataMessageForDevice(context.TODO(), params)
+				res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(Equal(operations.NewGetDataMessageForDeviceInternalServerError()))
@@ -642,6 +682,7 @@ var _ = Describe("Yggdrasil", func() {
 		Context("Metrics", func() {
 			var (
 				deviceName    string = "foo"
+				deviceCtx     context.Context
 				device        *v1alpha1.EdgeDevice
 				allowList     = models.MetricsAllowList{Names: []string{"foo", "bar"}}
 				allowListName = "foo"
@@ -649,6 +690,8 @@ var _ = Describe("Yggdrasil", func() {
 
 			BeforeEach(func() {
 				deviceName = "foo"
+
+				deviceCtx = context.WithValue(context.TODO(), AuthzKey, deviceName)
 				device = getDevice(deviceName)
 				device.Status.Deployments = []v1alpha1.Deployment{{Name: "workload1"}}
 
@@ -696,7 +739,7 @@ var _ = Describe("Yggdrasil", func() {
 					Return(&allowList, nil).Times(1)
 
 				// when
-				res := handler.GetDataMessageForDevice(context.TODO(), params)
+				res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -725,7 +768,7 @@ var _ = Describe("Yggdrasil", func() {
 					Return(nil, fmt.Errorf("Failed to get CM")).Times(1)
 
 				// when
-				res := handler.GetDataMessageForDevice(context.TODO(), params)
+				res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceInternalServerError{}))
@@ -763,7 +806,7 @@ var _ = Describe("Yggdrasil", func() {
 					Return(deploy, nil)
 
 				// when
-				res := handler.GetDataMessageForDevice(context.TODO(), params)
+				res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -789,7 +832,7 @@ var _ = Describe("Yggdrasil", func() {
 					Return(deploy, nil)
 
 				// when
-				res := handler.GetDataMessageForDevice(context.TODO(), params)
+				res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -838,7 +881,7 @@ var _ = Describe("Yggdrasil", func() {
 				Return(authFileContent, nil)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -888,7 +931,7 @@ var _ = Describe("Yggdrasil", func() {
 				Return("", fmt.Errorf("failure"))
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceInternalServerError{}))
@@ -952,7 +995,7 @@ var _ = Describe("Yggdrasil", func() {
 				Return(fmt.Errorf("test"))
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(Equal(operations.NewGetDataMessageForDeviceInternalServerError()))
@@ -1013,7 +1056,7 @@ var _ = Describe("Yggdrasil", func() {
 				Return(errorNotFound)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(Equal(operations.NewGetDataMessageForDeviceInternalServerError()))
@@ -1088,7 +1131,7 @@ var _ = Describe("Yggdrasil", func() {
 				Return(errorNotFound)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(Equal(operations.NewGetDataMessageForDeviceInternalServerError()))
@@ -1244,7 +1287,7 @@ var _ = Describe("Yggdrasil", func() {
 					Return(nil).Times(1)
 
 				// when
-				res := handler.GetDataMessageForDevice(context.TODO(), params)
+				res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(Equal(operations.NewGetDataMessageForDeviceInternalServerError()))
@@ -1504,7 +1547,7 @@ var _ = Describe("Yggdrasil", func() {
 				Return(errorNotFound).Times(1)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -1554,7 +1597,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -1592,7 +1635,7 @@ var _ = Describe("Yggdrasil", func() {
 				Return(&allowList, nil)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceOK{}))
@@ -1631,7 +1674,7 @@ var _ = Describe("Yggdrasil", func() {
 				Times(1)
 
 			// when
-			res := handler.GetDataMessageForDevice(context.TODO(), params)
+			res := handler.GetDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&operations.GetDataMessageForDeviceInternalServerError{}))
@@ -1643,10 +1686,12 @@ var _ = Describe("Yggdrasil", func() {
 		var (
 			deviceName string
 			device     *v1alpha1.EdgeDevice
+			deviceCtx  context.Context
 		)
 
 		BeforeEach(func() {
 			deviceName = "foo"
+			deviceCtx = context.WithValue(context.TODO(), AuthzKey, deviceName)
 			device = getDevice(deviceName)
 		})
 
@@ -1660,14 +1705,51 @@ var _ = Describe("Yggdrasil", func() {
 			}
 
 			// when
-			res := handler.PostDataMessageForDevice(context.TODO(), params)
+			res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 			// then
 			Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceBadRequest{}))
 		})
 
+		It("Invalid deviceID on context", func() {
+			// given
+			ctx := context.WithValue(context.TODO(), AuthzKey, "bar")
+			params := api.PostDataMessageForDeviceParams{
+				DeviceID: deviceName,
+				Message: &models.Message{
+					Directive: "NOT VALID ONE",
+				},
+			}
+
+			// when
+			res := handler.PostDataMessageForDevice(ctx, params)
+			emptyRes := handler.PostDataMessageForDevice(context.TODO(), params)
+
+			// then
+			Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceForbidden{}))
+			Expect(emptyRes).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceForbidden{}))
+		})
+
 		Context("Heartbeat", func() {
 			var directiveName = "heartbeat"
+
+			It("invalid deviceID on context", func() {
+				// given
+				ctx := context.WithValue(context.TODO(), AuthzKey, "bar")
+
+				params := api.PostDataMessageForDeviceParams{
+					DeviceID: deviceName,
+					Message: &models.Message{
+						Directive: directiveName,
+					},
+				}
+
+				// when
+				res := handler.PostDataMessageForDevice(ctx, params)
+
+				// then
+				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceForbidden{}))
+			})
 
 			It("Device not found", func() {
 				// given
@@ -1684,7 +1766,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceNotFound{}))
@@ -1705,7 +1787,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceInternalServerError{}))
@@ -1740,7 +1822,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceOK{}))
@@ -1797,7 +1879,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceOK{}))
@@ -1855,7 +1937,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceOK{}))
@@ -1917,7 +1999,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// test emmiting the events:
 				close(eventsRecorder.Events)
@@ -1946,7 +2028,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceBadRequest{}))
@@ -1987,7 +2069,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceInternalServerError{}))
@@ -2038,7 +2120,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceOK{}))
@@ -2124,7 +2206,7 @@ var _ = Describe("Yggdrasil", func() {
 					}
 
 					// when
-					res := handler.PostDataMessageForDevice(context.TODO(), params)
+					res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 					// then
 					Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceOK{}))
@@ -2172,7 +2254,7 @@ var _ = Describe("Yggdrasil", func() {
 					}
 
 					// when
-					res := handler.PostDataMessageForDevice(context.TODO(), params)
+					res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 					// then
 					Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceOK{}))
@@ -2244,7 +2326,7 @@ var _ = Describe("Yggdrasil", func() {
 					}
 
 					// when
-					res := handler.PostDataMessageForDevice(context.TODO(), params)
+					res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 					// then
 					Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceOK{}))
@@ -2282,7 +2364,7 @@ var _ = Describe("Yggdrasil", func() {
 					}
 
 					// when
-					res := handler.PostDataMessageForDevice(context.TODO(), params)
+					res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 					// then
 					Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceInternalServerError{}))
@@ -2336,7 +2418,7 @@ var _ = Describe("Yggdrasil", func() {
 					}
 
 					// when
-					res := handler.PostDataMessageForDevice(context.TODO(), params)
+					res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 					// then
 					Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceInternalServerError{}))
@@ -2360,7 +2442,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceOK{}))
@@ -2381,7 +2463,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceInternalServerError{}))
@@ -2432,7 +2514,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceOK{}))
@@ -2450,7 +2532,7 @@ var _ = Describe("Yggdrasil", func() {
 				}
 
 				// when
-				res := handler.PostDataMessageForDevice(context.TODO(), params)
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
 
 				// then
 				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceBadRequest{}))

--- a/pkg/mtls/ca_test.go
+++ b/pkg/mtls/ca_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	"github.com/project-flotta/flotta-operator/internal/yggdrasil"
 	"github.com/project-flotta/flotta-operator/pkg/mtls"
 )
 
@@ -536,7 +537,7 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 			}
 
 			// when
-			res := mtls.VerifyRequest(r, 0, opts, CAChain)
+			res := mtls.VerifyRequest(r, 0, opts, CAChain, yggdrasil.AuthzKey)
 
 			// then
 			Expect(res).To(BeFalse())
@@ -557,7 +558,7 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeTrue())
@@ -573,7 +574,7 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeFalse())
@@ -589,7 +590,7 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeTrue())
@@ -617,7 +618,7 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeTrue())
@@ -640,7 +641,7 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeFalse())
@@ -656,7 +657,7 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeTrue())
@@ -673,7 +674,7 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeFalse())
@@ -689,7 +690,7 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeTrue())
@@ -718,7 +719,7 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain)
+				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeFalse())

--- a/pkg/mtls/caprovider_secret.go
+++ b/pkg/mtls/caprovider_secret.go
@@ -225,7 +225,7 @@ func (config *CASecretProvider) SignCSR(CSRPem string, commonName string, expira
 		NotBefore:          time.Now().AddDate(0, 0, -1), // 1 day before for time drift issues
 		NotAfter:           expiration,
 		KeyUsage:           x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 	}
 
 	// We always make sure that commonName is the device one, so noone can try to

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -62,7 +62,7 @@ var _ = Describe("e2e", func() {
 			// then
 			// Check the edgedevice report proper state of workload:
 			err = device.WaitForDeploymentState("nginx", "Running")
-			Expect(err).To(BeNil())
+			Expect(err).To(BeNil(), "cannot get deployment status for nginx workload")
 
 			// Check the nginx is serving content:
 			stdout, err := device.Exec(fmt.Sprintf("curl http://localhost:%d", hostPort))
@@ -258,7 +258,7 @@ var _ = Describe("e2e", func() {
 			// then
 			// Check the edgedevice report proper state of workload:
 			err = device.WaitForDeploymentState("nginx", "Running")
-			Expect(err).To(BeNil())
+			Expect(err).To(BeNil(), "cannot get deployment status for nginx workload")
 
 			// Check the nginx is serving content:
 			stdout, err := device.Exec(fmt.Sprintf("curl http://localhost:%d", hostPort))

--- a/test/e2e/edgedevice_test.go
+++ b/test/e2e/edgedevice_test.go
@@ -156,6 +156,7 @@ func (e *edgeDeviceDocker) DumpLogs(extraCommands ...string) {
 		"journalctl -u podman",
 		"journalctl -u yggdrasild",
 		"ps aux",
+		"podman ps -a",
 		"systemctl status podman",
 		"systemctl status yggdrasild",
 	}


### PR DESCRIPTION
When a device access the API, it can update ANY device. And that was a
serious problem.

This commit changes how authorization is done, so mtls.VerifyRequest
sets a new key on the context, so when a request access one resource
that does not match with the `cert.subject.CommonName` it'll be rejected
with a 403.

Fix: ECOPROJECT-402

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>