### PR TITLE
API: Log correctly

### DIFF
--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -365,6 +365,8 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 		if err == nil {
 
 			if !IsOwnDevice(ctx, deviceID) {
+				authKeyVal, _ := ctx.Value(AuthzKey).(string)
+				logger.V(0).Info("Device tries to re-register with an invalid certificate", "certcn", authKeyVal)
 				// At this moment, the registration certificate it's no longer valid,
 				// because the CR is already created, and need to be a device
 				// certificate.

--- a/main.go
+++ b/main.go
@@ -317,7 +317,7 @@ func main() {
 					if r.TLS != nil {
 						authType := yggdrasilAPIHandler.GetAuthType(r, api)
 						if !mtls.VerifyRequest(r, authType, opts, CACertChain, yggdrasil.AuthzKey) {
-							setupLog.V(8).Info("Cannot verify request '%s:%s'  with Authtype: %d", r.Method, r.URL, authType)
+							setupLog.V(0).Info("Cannot verify request:", "authType", authType, "method", r.Method, "url", r.URL)
 							w.WriteHeader(http.StatusUnauthorized)
 							return
 						}


### PR DESCRIPTION
Some kinds jobs were failing, and Yggdrasil logs has some weird 401 out
there. With this changes we're going to be able to debug what happens on
the operator side.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>