### PR TITLE
MTLS: Verify request errors

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -23,6 +23,7 @@ jobs:
           kubectl wait --for=condition=Ready pods --all -n kube-system
 
           # Deploy flotta operator
+          sed -i 's/LOG_LEVEL=info/LOG_LEVEL=debug/g' config/manager/controller_manager_config.properties
           make build
           IMG=flotta-operator:latest make docker-build
           kind load docker-image flotta-operator:latest

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -43,6 +43,8 @@ jobs:
       - name: Collect all logs
         if: always()
         run: |
+          # Just dump the secrets to debug later
+          kubectl get secrets -n flotta -o json
           kind export logs dist
 
       - name: Archive logs

--- a/main.go
+++ b/main.go
@@ -316,8 +316,8 @@ func main() {
 				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if r.TLS != nil {
 						authType := yggdrasilAPIHandler.GetAuthType(r, api)
-						if !mtls.VerifyRequest(r, authType, opts, CACertChain, yggdrasil.AuthzKey) {
-							setupLog.V(0).Info("Cannot verify request:", "authType", authType, "method", r.Method, "url", r.URL)
+						if ok, err := mtls.VerifyRequest(r, authType, opts, CACertChain, yggdrasil.AuthzKey); !ok {
+							setupLog.V(0).Info("cannot verify request:", "authType", authType, "method", r.Method, "url", r.URL, "err", err)
 							w.WriteHeader(http.StatusUnauthorized)
 							return
 						}

--- a/pkg/mtls/ca.go
+++ b/pkg/mtls/ca.go
@@ -181,46 +181,53 @@ func (conf *TLSConfig) CreateRegistrationClientCerts() error {
 // least one give CA certificate. The main reason to do this and not
 // x509.Certificate.Cert(certStore) is because is checking expiration time, and
 // for registration endpoint, we cannot assume that it'll be ok.
-func isClientCertificateSigned(PeerCertificates []*x509.Certificate, CAChain []*x509.Certificate) bool {
+func isClientCertificateSigned(PeerCertificates []*x509.Certificate, CAChain []*x509.Certificate) (bool, error) {
+	var merr *multierror.Error
 	for _, cert := range PeerCertificates {
 		for _, caCert := range CAChain {
 			err := cert.CheckSignatureFrom(caCert)
 			// TODO log debug here with the error. Can be too verbose.
 			if err == nil {
-				return true
+				return true, nil
 			}
+			merr = multierror.Append(merr, err)
 		}
 	}
-	return false
+	return false, merr
 }
 
 // VerifyRequest check certificate based on the scenario needed:
 // registration endpoint: Any cert signed, even if it's expired.
-// All endpoints: checking that it's valid certificate.
+// All other endpoints: checking that it's valid certificate.
+// It returns true if it's allowed, and in case of false will return an Error
+// with the main reason.
 // @TODO check here the list of rejected certificates.
-func VerifyRequest(r *http.Request, verifyType int, verifyOpts x509.VerifyOptions, CACertChain []*x509.Certificate, authzKey RequestAuthKey) bool {
+func VerifyRequest(r *http.Request, verifyType int, verifyOpts x509.VerifyOptions, CACertChain []*x509.Certificate, authzKey RequestAuthKey) (bool, error) {
 
 	if len(r.TLS.PeerCertificates) == 0 {
-		return false
+		return false, &NoClientCertSendError{}
 	}
 
 	*r = *r.WithContext(context.WithValue(
 		r.Context(), authzKey, strings.ToLower(r.TLS.PeerCertificates[0].Subject.CommonName)))
 
 	if verifyType == YggdrasilRegisterAuth {
-		res := isClientCertificateSigned(r.TLS.PeerCertificates, CACertChain)
-		return res
+		res, err := isClientCertificateSigned(r.TLS.PeerCertificates, CACertChain)
+		if err != nil {
+			return res, &RegisterClientVerifyError{err}
+		}
+		return res, nil
 	}
 
 	for _, cert := range r.TLS.PeerCertificates {
 		if cert.Subject.CommonName == CertRegisterCN {
-			return false
+			return false, &InvalidCertificateKindError{}
 		}
 
 		if _, err := cert.Verify(verifyOpts); err != nil {
 			log.Log.V(5).Info("Failed to verify client cert: %v", err)
-			return false
+			return false, &ClientCertificateVerifyError{err}
 		}
 	}
-	return true
+	return true, nil
 }

--- a/pkg/mtls/ca_test.go
+++ b/pkg/mtls/ca_test.go
@@ -537,10 +537,11 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 			}
 
 			// when
-			res := mtls.VerifyRequest(r, 0, opts, CAChain, yggdrasil.AuthzKey)
+			res, err := mtls.VerifyRequest(r, 0, opts, CAChain, yggdrasil.AuthzKey)
 
 			// then
 			Expect(res).To(BeFalse())
+			Expect(err).To(BeAssignableToTypeOf(&mtls.NoClientCertSendError{}))
 		})
 
 		Context("Registration Auth", func() {
@@ -558,10 +559,11 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
+				res, err := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("Peer certificate is invalid", func() {
@@ -574,10 +576,11 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
+				res, err := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeFalse())
+				Expect(err).To(BeAssignableToTypeOf(&mtls.RegisterClientVerifyError{}))
 			})
 
 			It("Last CA certificate is valid", func() {
@@ -590,10 +593,11 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
+				res, err := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("Expired certificate is valid", func() {
@@ -618,10 +622,11 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
+				res, err := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 		})
@@ -641,10 +646,11 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
+				res, err := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeFalse())
+				Expect(err).To(BeAssignableToTypeOf(&mtls.InvalidCertificateKindError{}))
 			})
 
 			It("Certificate is correct", func() {
@@ -657,10 +663,11 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
+				res, err := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("Invalid certificate is rejected", func() {
@@ -674,10 +681,12 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
+				res, err := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeFalse())
+				Expect(err).To(BeAssignableToTypeOf(&mtls.ClientCertificateVerifyError{}))
+
 			})
 
 			It("Certificate valid with any CA position on the store.", func() {
@@ -690,10 +699,11 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
+				res, err := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("Expired certificate is not working", func() {
@@ -719,10 +729,11 @@ KoZIhvcNAQEBBQA-----END CERTIFICATE REQUEST-----
 				}
 
 				// when
-				res := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
+				res, err := mtls.VerifyRequest(r, AuthType, opts, CAChain, yggdrasil.AuthzKey)
 
 				// then
 				Expect(res).To(BeFalse())
+				Expect(err).To(BeAssignableToTypeOf(&mtls.ClientCertificateVerifyError{}))
 			})
 
 		})

--- a/pkg/mtls/cert_utils.go
+++ b/pkg/mtls/cert_utils.go
@@ -206,6 +206,9 @@ func getCACertificate() (*CertificateGroup, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Cannot parse PEM certificate: %v", err)
 	}
+
+	// Just pushed the signed cert, so PubkeyAlgo is present on the cert
+	certificateBundle.cert = certificateBundle.signedCert
 	return &certificateBundle, nil
 }
 

--- a/pkg/mtls/errors.go
+++ b/pkg/mtls/errors.go
@@ -1,0 +1,31 @@
+package mtls
+
+import "fmt"
+
+type NoClientCertSendError struct{}
+
+func (e *NoClientCertSendError) Error() string {
+	return "no Client cert was sent"
+}
+
+type RegisterClientVerifyError struct {
+	err error
+}
+
+func (e *RegisterClientVerifyError) Error() string {
+	return fmt.Sprintf("cannot verify register certificate: %v", e.err)
+}
+
+type InvalidCertificateKindError struct{}
+
+func (e *InvalidCertificateKindError) Error() string {
+	return "cannot use register certificate on this resource"
+}
+
+type ClientCertificateVerifyError struct {
+	err error
+}
+
+func (e *ClientCertificateVerifyError) Error() string {
+	return fmt.Sprintf("cannot verify certificate: %v", e.err)
+}


### PR DESCRIPTION
 When VerifyRequest failed there is no clear way to know if it was an invalid certificate, not present or something different.

These commits address a few things:

- A way to dump the secrets on GH actions.
- Fix the Verify function to validate why it fails. 
- A fix on mtls.CA to fix some flakes where CA certificate was not signed correctly.  
- Add the operator with debug level on GH actions. 
