### PR TITLE
Fix: use flotta-project quay.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ else ifeq ($(TARGET), kind)
 	$(KUSTOMIZE) build config/kind > $(TMP_ODIR)/$(TARGET)-flotta-operator.yaml
 endif
 
-	@cd config/manager && $(KUSTOMIZE) edit set image controller=quay.io/jdzon/flotta-operator:latest
+	@cd config/manager && $(KUSTOMIZE) edit set image controller=quay.io/flotta-operator/flotta-operator:latest
 	@echo -e "\033[92mDeployment file: $(TMP_ODIR)/$(TARGET)-flotta-operator.yaml\033[0m"
 
 release:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/jdzon/flotta-operator
+  newName: quay.io/flotta-operator/flotta-operator
   newTag: latest


### PR DESCRIPTION
There is a residual typo from migration to Flotta in `quaio.io` link in `gen-manifest` Makefile target

Signed-off-by: Gloria Ciavarrini <gciavarrini@redhat.com>