### PR TITLE
Add `JustAfterEach()` to e2e test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -40,15 +40,22 @@ var _ = Describe("e2e", func() {
 
 	})
 
-	AfterFailed(func() {
-		device.DumpLogs()
-	})
-
 	AfterEach(func() {
 		_ = deployment.RemoveAll()
 		_ = device.Unregister()
 		_ = device.Remove()
 	})
+
+	JustAfterEach(func() {
+		isValid, err := device.ValidateNoDataRaceInLogs()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isValid).To(BeTrue(),"Found data race in logs" )
+	})
+
+	AfterFailed(func() {
+		device.DumpLogs()
+	})
+
 	Context("Sanity", func() {
 		It("Deploy valid edgedeployment to registered device", func() {
 			// given


### PR DESCRIPTION
Added use of `JustAfterEach()` in order to indicate if there are race conditions reported to the log.

Signed-off-by: arielireni <aireni@redhat.com>