### PR TITLE
enable TLS for metrics remote writer

### DIFF
--- a/api/v1alpha1/edgedevice_types.go
+++ b/api/v1alpha1/edgedevice_types.go
@@ -44,6 +44,7 @@ type MetricsReceiverConfiguration struct {
 	RequestNumSamples int64  `json:"requestNumSamples,omitempty"`
 	TimeoutSeconds    int64  `json:"timeoutSeconds,omitempty"`
 	URL               string `json:"url,omitempty"`
+	CaSecretName      string `json:"caSecretName,omitempty"`
 }
 
 type LogCollectionConfig struct {

--- a/config/crd/bases/management.project-flotta.io_edgedevicegroups.yaml
+++ b/config/crd/bases/management.project-flotta.io_edgedevicegroups.yaml
@@ -85,6 +85,8 @@ spec:
                 properties:
                   receiverConfiguration:
                     properties:
+                      caSecretName:
+                        type: string
                       requestNumSamples:
                         format: int64
                         type: integer

--- a/config/crd/bases/management.project-flotta.io_edgedevices.yaml
+++ b/config/crd/bases/management.project-flotta.io_edgedevices.yaml
@@ -82,6 +82,8 @@ spec:
                 properties:
                   receiverConfiguration:
                     properties:
+                      caSecretName:
+                        type: string
                       requestNumSamples:
                         format: int64
                         type: integer

--- a/docs/design/http_api_swagger.md
+++ b/docs/design/http_api_swagger.md
@@ -792,6 +792,7 @@ Status: Internal Server Error
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
+| caCert | string| `string` |  | |  |  |
 | request_num_samples | integer| `int64` |  | |  |  |
 | timeout_seconds | integer| `int64` |  | |  |  |
 | url | string| `string` |  | |  |  |

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -o nounset
 set -o pipefail
 set -o errexit
 

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -3,6 +3,7 @@ package yggdrasil
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/project-flotta/flotta-operator/internal/configmaps"
 	"github.com/project-flotta/flotta-operator/internal/devicemetrics"
 	"github.com/project-flotta/flotta-operator/internal/heartbeat"

--- a/models/metrics_receiver_configuration.go
+++ b/models/metrics_receiver_configuration.go
@@ -15,6 +15,9 @@ import (
 // swagger:model metrics-receiver-configuration
 type MetricsReceiverConfiguration struct {
 
+	// ca cert
+	CaCert string `json:"caCert,omitempty"`
+
 	// request num samples
 	RequestNumSamples int64 `json:"request_num_samples,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -767,6 +767,9 @@ func init() {
     "metrics-receiver-configuration": {
       "type": "object",
       "properties": {
+        "caCert": {
+          "type": "string"
+        },
         "request_num_samples": {
           "type": "integer"
         },
@@ -1791,6 +1794,9 @@ func init() {
     "metrics-receiver-configuration": {
       "type": "object",
       "properties": {
+        "caCert": {
+          "type": "string"
+        },
         "request_num_samples": {
           "type": "integer"
         },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -195,6 +195,8 @@ definitions:
         type: integer
       request_num_samples:
         type: integer
+      caCert:
+        type: string
 
   logs-collection-information:
     description: Log collection information


### PR DESCRIPTION
pass an optional CA to the device
This is the CA that signs the metrics receiver's certificate

https://issues.redhat.com/browse/ECOPROJECT-579
enable TLS in device remote write

Signed-off-by: Yaron Dayagi <ydayagi@redhat.com>