### PR TITLE
Add golanci-lint and goimports targets

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,7 +54,6 @@ run:
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
   go: '1.17'
 
-
 # output configuration options
 output:
   # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
@@ -65,7 +64,7 @@ output:
   # Example: "checkstyle:report.json,colored-line-number"
   #
   # Default: colored-line-number
-  format: colored-line-number 
+  format: colored-line-number
 
   # Print lines of code with issue.
   # Default: true
@@ -189,5 +188,3 @@ linters:
     - style
     - test
     - unused
-
-

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,9 +50,7 @@ run:
   allow-parallel-runners: false
 
   # Define the Go version limit.
-  # Mainly related to generics support in go1.18.
-  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
-  go: '1.17'
+  go: '1.16'
 
 # output configuration options
 output:
@@ -92,99 +90,22 @@ linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
   enable:
-    - asciicheck
-    - bidichk
-    - bodyclose
-    - contextcheck
-    - cyclop
+  # default linter
     - deadcode
-    - depguard
-    - dogsled
-    - dupl
-    - durationcheck
     - errcheck
-    - errname
-    - errorlint
-    - exhaustive
-    - exhaustivestruct
-    - exportloopref
-    - forbidigo
-    - forcetypeassert
-    - funlen
-    - gci
-    - gochecknoglobals
-    - gochecknoinits
-    - gocognit
-    - goconst
-    - gocritic
-    - gocyclo
-    - godot
-    - godox
-    - goerr113
-    - gofmt
-    - gofumpt
-    - goheader
-    - goimports
-    - gomnd
-    - gomoddirectives
-    - gomodguard
-    - goprintffuncname
-    - gosec
     - gosimple
     - govet
-    - ifshort
-    - importas
     - ineffassign
-    - ireturn
-    - lll
-    - makezero
-    - misspell
-    - nakedret
-    - nestif
-    - nilerr
-    - nilnil
-    - nlreturn
-    - noctx
-    - nolintlint
-    - paralleltest
-    - prealloc
-    - predeclared
-    - promlinter
-    - revive
-    - rowserrcheck
-    - sqlclosecheck
     - staticcheck
     - structcheck
-    - stylecheck
-    - tagliatelle
-    - tenv
-    - testpackage
-    - thelper
-    - tparallel
     - typecheck
-    - unconvert
-    - unparam
     - unused
     - varcheck
-    - varnamelen
-    - wastedassign
-    - whitespace
-    - wrapcheck
-    - wsl
-
-  # Enable presets.
-  # https://golangci-lint.run/usage/linters
-  presets:
-    - bugs
-    - comment
-    - complexity
-    - error
-    - format
-    - import
-    - metalinter
-    - module
-    - performance
-    - sql
-    - style
-    - test
-    - unused
+  # additional linters
+    - bodyclose
+    - errorlint
+    - exportloopref
+    - forcetypeassert
+    - nilerr
+    - prealloc
+    - unparam

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,7 +50,7 @@ run:
   allow-parallel-runners: false
 
   # Define the Go version limit.
-  go: '1.16'
+  go: '1.17'
 
 # output configuration options
 output:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,4 @@
+---
 # Options for analysis running.
 run:
   # The default concurrency value is the number of available CPU.
@@ -90,7 +91,7 @@ linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
   enable:
-  # default linter
+    # default linter
     - deadcode
     - errcheck
     - gosimple
@@ -101,7 +102,7 @@ linters:
     - typecheck
     - unused
     - varcheck
-  # additional linters
+    # additional linters
     - bodyclose
     - errorlint
     - exportloopref

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,193 @@
+# Options for analysis running.
+run:
+  # The default concurrency value is the number of available CPU.
+  concurrency: 4
+
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 5m
+
+  # Exit code when at least one issue was found.
+  # Default: 1
+  issues-exit-code: 2
+
+  # Include test files or not.
+  # Default: true
+  tests: false
+
+  # Which dirs to skip: issues from them won't be reported.
+  # Can use regexp here: `generated.*`, regexp is applied on full path.
+  # Default value is empty list,
+  # but default dirs are skipped independently of this option's value (see skip-dirs-use-default).
+  # "/" will be replaced by current OS file path separator to properly work on Windows.
+  skip-dirs:
+    - api
+    - test
+    - hack
+    - client
+    - vendor
+
+  # Enables skipping of directories:
+  # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  # Default: true
+  skip-dirs-use-default: false
+
+  # If setwe pass it to "go list -mod={option}". From "go help modules":
+  # If invoked with -mod=readonly, the go command is disallowed from the implicit
+  # automatic updating of go.mod described above. Instead, it fails when any changes
+  # to go.mod are needed. This setting is most useful to check that go.mod does
+  # not need updates, such as in a continuous integration and testing system.
+  # If invoked with -mod=vendor, the go command assumes that the vendor
+  # directory holds the correct copies of dependencies and ignores
+  # the dependency descriptions in go.mod.
+  #
+  # Allowed values: readonly|vendor|mod
+  # By default, it isn't set.
+  modules-download-mode: readonly
+
+  # Allow multiple parallel golangci-lint instances running.
+  # If false (default) - golangci-lint acquires file lock on start.
+  allow-parallel-runners: false
+
+  # Define the Go version limit.
+  # Mainly related to generics support in go1.18.
+  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
+  go: '1.17'
+
+
+# output configuration options
+output:
+  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  #
+  # Multiple can be specified by separating them by comma, output can be provided
+  # for each of them by separating format name and path by colon symbol.
+  # Output path can be either `stdout`, `stderr` or path to the file to write to.
+  # Example: "checkstyle:report.json,colored-line-number"
+  #
+  # Default: colored-line-number
+  format: colored-line-number 
+
+  # Print lines of code with issue.
+  # Default: true
+  print-issued-lines: false
+
+  # Print linter name in the end of issue text.
+  # Default: true
+  print-linter-name: true
+
+  # Make issues output unique by line.
+  # Default: true
+  uniq-by-line: true
+
+  # Add a prefix to the output file references.
+  # Default is no prefix.
+  path-prefix: ""
+
+  # Sort results by: filepath, line and column.
+  sort-results: true
+
+linters:
+  # Disable all linters.
+  # Default: false
+  disable-all: true
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+  enable:
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - cyclop
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - exhaustivestruct
+    - exportloopref
+    - forbidigo
+    - forcetypeassert
+    - funlen
+    - gci
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - goerr113
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - gomnd
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ifshort
+    - importas
+    - ineffassign
+    - ireturn
+    - lll
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - nlreturn
+    - noctx
+    - nolintlint
+    - paralleltest
+    - prealloc
+    - predeclared
+    - promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - tagliatelle
+    - tenv
+    - testpackage
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - varnamelen
+    - wastedassign
+    - whitespace
+    - wrapcheck
+    - wsl
+
+  # Enable presets.
+  # https://golangci-lint.run/usage/linters
+  presets:
+    - bugs
+    - comment
+    - complexity
+    - error
+    - format
+    - import
+    - metalinter
+    - module
+    - performance
+    - sql
+    - style
+    - test
+    - unused
+
+

--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,14 @@ gosec: ## Run gosec locally
 	$(DOCKER) run --rm -it -v $(PWD):/opt/data/:z docker.io/securego/gosec -exclude-generated /opt/data/...
 
 GO_IMAGE=golang:1.17.8-alpine3.14
+GOIMPORTS_IMAGE=golang.org/x/tools/cmd/goimports@latest
 FILES_LIST=$(shell ls -d */ | grep -v -E "vendor|tools|test|client|restapi|models")
 MODULE_NAME=$(shell head -n 1 go.mod | cut -d '/' -f 3)
 imports: ## fix and format go imports
 	@# Removes blank lines within import block so that goimports does its magic in a deterministic way
 	find $(FILES_LIST) -type f -name "*.go" | xargs -L 1 sed -i '/import (/,/)/{/import (/n;/)/!{/^$$/d}}'
 	$(DOCKER) run --rm -v $(CURDIR):$(CURDIR) -w="$(CURDIR)" $(GO_IMAGE) \
-		sh -c 'go install golang.org/x/tools/cmd/goimports@latest && goimports -w -local github.com/project-flotta $(FILES_LIST) && goimports -w -local github.com/project-flotta/$(MODULE_NAME) $(FILES_LIST)'
+		sh -c 'go install $(GOIMPORTS_IMAGE) && goimports -w -local github.com/project-flotta $(FILES_LIST) && goimports -w -local github.com/project-flotta/$(MODULE_NAME) $(FILES_LIST)'
 
 LINT_IMAGE=golangci/golangci-lint:v1.45.0
 lint: ## Check if the go code is properly written, rules are in .golangci.yml 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 gosec: ## Run gosec locally
-	$(DOCKER) run --rm -it -v $(PWD):/opt/data/:z docker.io/securego/gosec -exclude-generated /opt/data/...
+	$(DOCKER) run --rm -v $(PWD):/opt/data/:z docker.io/securego/gosec -exclude-generated /opt/data/...
 
 GO_IMAGE=golang:1.17.8-alpine3.14
 GOIMPORTS_IMAGE=golang.org/x/tools/cmd/goimports@latest
@@ -99,7 +99,7 @@ imports: ## fix and format go imports
 
 LINT_IMAGE=golangci/golangci-lint:v1.45.0
 lint: ## Check if the go code is properly written, rules are in .golangci.yml 
-	docker run --rm -v $(CURDIR):$(CURDIR) -w="$(CURDIR)" $(LINT_IMAGE) sh -c 'golangci-lint run'
+	$(DOCKER) run --rm -v $(CURDIR):$(CURDIR) -w="$(CURDIR)" $(LINT_IMAGE) sh -c 'golangci-lint run'
 
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
@@ -109,7 +109,7 @@ test: manifests generate fmt vet test-fast ## Run tests.
 
 integration-test: ginkgo get-certs
 	$(DOCKER) pull quay.io/project-flotta/edgedevice
-	$(GINKGO) -focus=$(FOCUS) run test/e2e
+	$(GINKGO) -v run test/e2e
 
 TEST_PACKAGES := ./...
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ test: manifests generate fmt vet test-fast ## Run tests.
 
 integration-test: ginkgo get-certs
 	$(DOCKER) pull quay.io/project-flotta/edgedevice
-	$(GINKGO) -v run test/e2e
+	$(GINKGO) -focus=$(FOCUS) run test/e2e
 
 TEST_PACKAGES := ./...
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ check-certs: # Check cert subject
 	openssl x509 -noout -in /tmp/cert.pem --subject
 
 ##@ Build
-build: generate fmt vet gosec imports ## Build manager binary.
+build: generate fmt vet imports ## Build manager binary.
 	go build -mod=vendor -o bin/manager main.go
 
 fast-build: generate fmt vet ## Fast build manager binary for local dev.

--- a/controllers/edgedevice_controller.go
+++ b/controllers/edgedevice_controller.go
@@ -18,9 +18,10 @@ package controllers
 
 import (
 	"context"
+	"time"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"time"
 
 	obv1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	"github.com/project-flotta/flotta-operator/internal/metrics"
@@ -99,7 +100,7 @@ func (r *EdgeDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *EdgeDeviceReconciler) createOrGetObc(ctx context.Context, edgeDevice *managementv1alpha1.EdgeDevice) (*obv1.ObjectBucketClaim, error) {
 	obc, err := r.Claimer.GetClaim(ctx, edgeDevice.Name, edgeDevice.Namespace)
 	if err == nil {
-		return obc, err
+		return obc, nil
 	}
 
 	logger := log.FromContext(ctx, "EdgeDevice Name", edgeDevice.Name, "EdgeDevice Namespace", edgeDevice.Namespace)

--- a/controllers/edgeworkload_controller_test.go
+++ b/controllers/edgeworkload_controller_test.go
@@ -661,13 +661,13 @@ var _ = Describe("Controllers", func() {
 				actualSplit   map[int]int
 				syncMap       = sync.Mutex{}
 			)
-			executeConcurrent := func(concurrency uint, f controllers.ConcurrentFunc, devices []v1alpha1.EdgeDevice) []error {
+			executeConcurrent := func(ctx context.Context, concurrency uint, f controllers.ConcurrentFunc, devices []v1alpha1.EdgeDevice) []error {
 				if len(devices) == 0 {
 					return nil
 				}
-				testF := func(devices []v1alpha1.EdgeDevice) []error {
+				testF := func(ctx context.Context, devices []v1alpha1.EdgeDevice) []error {
 					defer GinkgoRecover()
-					errs := f(devices)
+					errs := f(context.Background(), devices)
 					lenErrs := len(errs)
 					syncMap.Lock()
 					val, ok := actualSplit[lenErrs]
@@ -680,7 +680,7 @@ var _ = Describe("Controllers", func() {
 					syncMap.Unlock()
 					return errs
 				}
-				_ = controllers.ExecuteConcurrent(concurrency, testF, devices)
+				_ = controllers.ExecuteConcurrent(context.Background(), concurrency, testF, devices)
 				return nil
 			}
 

--- a/internal/configmaps/configmaps.go
+++ b/internal/configmaps/configmaps.go
@@ -40,7 +40,10 @@ func (cm *configMap) Fetch(ctx context.Context, workload v1alpha1.EdgeWorkload, 
 
 		// Extract info also from volumes:
 		utils.ExtractInfoFromVolume(podSpec.Volumes, cmMap, func(i interface{}) (bool, *bool, string) {
-			volume := i.(corev1.Volume)
+			volume, ok := i.(corev1.Volume)
+			if !ok {
+				return false, nil, ""
+			}
 			if volume.ConfigMap != nil {
 				return true, volume.ConfigMap.Optional, volume.ConfigMap.Name
 			}
@@ -52,7 +55,7 @@ func (cm *configMap) Fetch(ctx context.Context, workload v1alpha1.EdgeWorkload, 
 	for name, keys := range cmMap {
 		configmapObj, err := cm.readAndValidateConfigMap(ctx, name, namespace, keys)
 		if err != nil {
-			return nil, fmt.Errorf("Can't fetch the configmap %v/%v: %v", name, namespace, err)
+			return nil, fmt.Errorf("Can't fetch the configmap %v/%v: %w", name, namespace, err)
 		}
 		if configmapObj == nil {
 			continue
@@ -90,7 +93,10 @@ func (cm *configMap) readAndValidateConfigMap(ctx context.Context, configmapName
 
 func extractConfigMapsFromEnv(container *corev1.Container, configmapMap utils.MapType) {
 	utils.ExtractInfoFromEnvFrom(container.EnvFrom, configmapMap, func(e interface{}) (bool, *bool, string) {
-		env := e.(corev1.EnvFromSource)
+		env, ok := e.(corev1.EnvFromSource)
+		if !ok {
+			return false, nil, ""
+		}
 		if env.ConfigMapRef != nil {
 			return true, env.ConfigMapRef.Optional, env.ConfigMapRef.Name
 		}

--- a/internal/heartbeat/updater.go
+++ b/internal/heartbeat/updater.go
@@ -2,9 +2,10 @@ package heartbeat
 
 import (
 	"context"
-	mtrcs "github.com/project-flotta/flotta-operator/internal/metrics"
 	"reflect"
 	"time"
+
+	mtrcs "github.com/project-flotta/flotta-operator/internal/metrics"
 
 	"github.com/project-flotta/flotta-operator/api/v1alpha1"
 	"github.com/project-flotta/flotta-operator/internal/hardware"
@@ -76,7 +77,7 @@ func updateDeploymentStatuses(oldWorkloads []v1alpha1.Workload, workloads []*mod
 			edgeWorkloadMap[status.Name] = edgeWorkload
 		}
 	}
-	var edgeWorkloads []v1alpha1.Workload
+	edgeWorkloads := make([]v1alpha1.Workload, 0, len(edgeWorkloadMap))
 	for _, edgeWorkload := range edgeWorkloadMap {
 		edgeWorkloads = append(edgeWorkloads, edgeWorkload)
 	}

--- a/internal/heartbeat/updater.go
+++ b/internal/heartbeat/updater.go
@@ -77,7 +77,7 @@ func updateDeploymentStatuses(oldWorkloads []v1alpha1.Workload, workloads []*mod
 			edgeWorkloadMap[status.Name] = edgeWorkload
 		}
 	}
-	edgeWorkloads := make([]v1alpha1.Workload, 0, len(edgeWorkloadMap))
+	var edgeWorkloads []v1alpha1.Workload //nolint
 	for _, edgeWorkload := range edgeWorkloadMap {
 		edgeWorkloads = append(edgeWorkloads, edgeWorkload)
 	}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -18,7 +18,10 @@ const (
 )
 
 func WorkloadByDeviceIndexFunc(obj ctrlruntimeclient.Object) []string {
-	workload := obj.(*v1alpha1.EdgeWorkload)
+	workload, ok := obj.(*v1alpha1.EdgeWorkload)
+	if !ok {
+		return []string{}
+	}
 	var keys []string
 	for name, value := range workload.Labels {
 		if flottalabels.IsSelectorLabel(name) {
@@ -29,7 +32,10 @@ func WorkloadByDeviceIndexFunc(obj ctrlruntimeclient.Object) []string {
 }
 
 func DeviceByWorkloadIndexFunc(obj ctrlruntimeclient.Object) []string {
-	device := obj.(*v1alpha1.EdgeDevice)
+	device, ok := obj.(*v1alpha1.EdgeDevice)
+	if !ok {
+		return []string{}
+	}
 	var keys []string
 	// iterate over labels map and return a list of workloads as keys
 	for name := range device.Labels {

--- a/internal/informers/edgedevice.go
+++ b/internal/informers/edgedevice.go
@@ -14,12 +14,14 @@ func NewEdgeDeviceEventHandler(metrics mtrcs.Metrics) *edgeDeviceEventHandler {
 }
 
 func (h *edgeDeviceEventHandler) OnAdd(obj interface{}) {
-	edgeDevice := obj.(*v1alpha1.EdgeDevice)
-	h.metrics.RegisterDeviceCounter(edgeDevice.Namespace, edgeDevice.Name)
+	if edgeDevice, ok := obj.(*v1alpha1.EdgeDevice); ok {
+		h.metrics.RegisterDeviceCounter(edgeDevice.Namespace, edgeDevice.Name)
+	}
 }
 func (h *edgeDeviceEventHandler) OnDelete(obj interface{}) {
-	edgeDevice := obj.(*v1alpha1.EdgeDevice)
-	h.metrics.RemoveDeviceCounter(edgeDevice.Namespace, edgeDevice.Name)
+	if edgeDevice, ok := obj.(*v1alpha1.EdgeDevice); ok {
+		h.metrics.RemoveDeviceCounter(edgeDevice.Namespace, edgeDevice.Name)
+	}
 }
 
 func (h *edgeDeviceEventHandler) OnUpdate(_, _ interface{}) {}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -2,9 +2,10 @@ package metrics
 
 import (
 	"fmt"
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
-	"sync"
 )
 
 // When adding metric names, see https://prometheus.io/docs/practices/naming/#metric-names
@@ -88,7 +89,7 @@ func (m *metricsImpl) IncEdgeDeviceUnregistration() {
 
 func (m *metricsImpl) RemoveDeviceCounter(namespace, name string) {
 	if counter, ok := m.devices.LoadAndDelete(deviceKey(namespace, name)); ok {
-		metrics.Registry.Unregister(counter.(prometheus.Counter))
+		metrics.Registry.Unregister(counter.(prometheus.Counter)) //nolint
 	}
 }
 
@@ -103,7 +104,7 @@ func (m *metricsImpl) registerDeviceCounter(namespace, name string) prometheus.C
 			},
 		}))
 
-	counter := collector.(prometheus.Counter)
+	counter := collector.(prometheus.Counter) //nolint
 	if !loaded {
 		metrics.Registry.MustRegister(counter)
 	}

--- a/internal/yggdrasil/configuration-assembler.go
+++ b/internal/yggdrasil/configuration-assembler.go
@@ -63,7 +63,7 @@ func (a *configurationAssembler) getDeviceConfiguration(ctx context.Context, edg
 		if err != nil {
 			return nil, err
 		}
-		secretList, err = a.createSecretList(ctx, logger, edgeWorkloads, edgeDevice)
+		secretList, err = a.createSecretList(ctx, edgeWorkloads, edgeDevice)
 		if err != nil {
 			logger.Error(err, "failed reading secrets for device workloads")
 			return nil, err
@@ -271,7 +271,7 @@ func (a *configurationAssembler) toWorkloadList(ctx context.Context, logger logr
 			if allowListSpec := spec.Metrics.AllowList; allowListSpec != nil {
 				allowList, err := a.allowLists.GenerateFromConfigMap(ctx, allowListSpec.Name, edgeworkload.Namespace)
 				if err != nil {
-					return nil, fmt.Errorf("Cannot get AllowList Metrics Confimap for %v: %v", edgeworkload.Name, err)
+					return nil, fmt.Errorf("Cannot get AllowList Metrics Confimap for %v: %w", edgeworkload.Name, err)
 				}
 				workload.Metrics.AllowList = allowList
 			}
@@ -315,7 +315,7 @@ func (a *configurationAssembler) getAuthFile(ctx context.Context, imageRegistrie
 	return "", nil
 }
 
-func (a *configurationAssembler) createSecretList(ctx context.Context, logger logr.Logger, workloads []v1alpha1.EdgeWorkload, device *v1alpha1.EdgeDevice) (models.SecretList, error) {
+func (a *configurationAssembler) createSecretList(ctx context.Context, workloads []v1alpha1.EdgeWorkload, device *v1alpha1.EdgeDevice) (models.SecretList, error) {
 	list := models.SecretList{}
 
 	// create map of secret names and keys
@@ -475,7 +475,7 @@ func (a *configurationAssembler) getDeviceSyslogLogConfig(ctx context.Context, n
 		client.ObjectKey{Namespace: namespace, Name: val.SyslogConfig.Name},
 		&cm)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get syslogconfig from configmap %s: %v", val.SyslogConfig.Name, err)
+		return nil, fmt.Errorf("cannot get syslogconfig from configmap %s: %w", val.SyslogConfig.Name, err)
 	}
 	proto := "tcp"
 	if cmproto, ok := cm.Data["Protocol"]; ok {

--- a/pkg/mtls/ca.go
+++ b/pkg/mtls/ca.go
@@ -112,7 +112,7 @@ func (conf *TLSConfig) InitCertificates() (*tls.Config, []*x509.Certificate, err
 		caCert, err := caProvider.GetCACertificate()
 		if err != nil {
 			errors = multierror.Append(errors, fmt.Errorf(
-				"cannot get CA certificate for provider %s: %v",
+				"cannot get CA certificate for provider %s: %w",
 				caProvider.GetName(), err))
 			continue
 		}
@@ -138,7 +138,7 @@ func (conf *TLSConfig) InitCertificates() (*tls.Config, []*x509.Certificate, err
 
 	certificate, err := serverCert.GetCertificate()
 	if err != nil {
-		return nil, nil, fmt.Errorf("Cannot create server certfificate: %v", err)
+		return nil, nil, fmt.Errorf("Cannot create server certfificate: %w", err)
 	}
 
 	tlsConfig := &tls.Config{

--- a/pkg/mtls/caprovider_secret.go
+++ b/pkg/mtls/caprovider_secret.go
@@ -113,7 +113,7 @@ func (config *CASecretProvider) GetServerCertificate(dnsNames []string, localhos
 	}, &secret)
 
 	if err != nil && !errors.IsNotFound(err) {
-		return nil, fmt.Errorf("cannot get Host TLS cert:%v", err)
+		return nil, fmt.Errorf("cannot get Host TLS cert: %w", err)
 	}
 
 	if err == nil {
@@ -125,19 +125,19 @@ func (config *CASecretProvider) GetServerCertificate(dnsNames []string, localhos
 		}
 
 		if err := certGroup.ImportFromPem(); err != nil {
-			return nil, fmt.Errorf("cannot import server cert from configmap: %v", err)
+			return nil, fmt.Errorf("cannot import server cert from configmap: %w", err)
 		}
 		return certGroup, err
 	}
 
 	CACert, err := config.GetCACertificate()
 	if err != nil {
-		return nil, fmt.Errorf("cannot get Host CA TLS cert:%v", err)
+		return nil, fmt.Errorf("cannot get Host CA TLS cert: %w", err)
 	}
 
 	cert, err := getServerCertificate(dnsNames, localhostEnabled, CACert)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create host TLS cert:%v", err)
+		return nil, fmt.Errorf("cannot create host TLS cert: %w", err)
 	}
 
 	secret = corev1.Secret{
@@ -153,7 +153,7 @@ func (config *CASecretProvider) GetServerCertificate(dnsNames []string, localhos
 
 	err = config.client.Create(context.TODO(), &secret)
 	if err != nil {
-		return nil, fmt.Errorf("cannot store server cert: %v", err)
+		return nil, fmt.Errorf("cannot store server cert: %w", err)
 	}
 	return cert, nil
 }
@@ -180,12 +180,12 @@ func (config *CASecretProvider) CreateRegistrationCertificate(name string) (map[
 
 	certGroup, err := createKeyAndCSR(cert, CACert)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot sign certificate request: %v", err)
+		return nil, fmt.Errorf("Cannot sign certificate request: %w", err)
 	}
 
 	err = certGroup.CreatePem()
 	if err != nil {
-		return nil, fmt.Errorf("Cannot encode certs: %v", err)
+		return nil, fmt.Errorf("Cannot encode certs: %w", err)
 	}
 
 	res := map[string][]byte{
@@ -212,7 +212,7 @@ func (config *CASecretProvider) SignCSR(CSRPem string, commonName string, expira
 
 	CSR, err := x509.ParseCertificateRequest(decodecCert.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse CSR: %v", err)
+		return nil, fmt.Errorf("cannot parse CSR: %w", err)
 	}
 
 	clientCert := &x509.Certificate{
@@ -236,7 +236,7 @@ func (config *CASecretProvider) SignCSR(CSRPem string, commonName string, expira
 	certBytes, err := x509.CreateCertificate(
 		rand.Reader, clientCert, config.latestCA.cert, CSR.PublicKey, config.latestCA.privKey)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot sign certificate reques: %v", err)
+		return nil, fmt.Errorf("Cannot sign certificate reques: %w", err)
 	}
 
 	certPEM := pem.EncodeToMemory(&pem.Block{

--- a/pkg/mtls/cert_utils.go
+++ b/pkg/mtls/cert_utils.go
@@ -51,7 +51,7 @@ func (c *CertificateGroup) ImportFromPem() error {
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return fmt.Errorf("Failing parsing cert: %v", err)
+		return fmt.Errorf("Failing parsing cert: %w", err)
 	}
 	err = c.decodePrivKeyFromPEM()
 	if err != nil {
@@ -78,7 +78,7 @@ func (c *CertificateGroup) decodePrivKeyFromPEM() error {
 	case RSAPrivateKeyBlockType:
 		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 		if err != nil {
-			return fmt.Errorf("failing parsing key: %v", err)
+			return fmt.Errorf("failing parsing key: %w", err)
 		}
 		c.privKey = key
 	default:
@@ -99,7 +99,7 @@ func (c *CertificateGroup) CreatePem() error {
 	}
 	privKeyPEM, err := c.MarshalKeyToPem(c.privKey)
 	if err != nil {
-		return fmt.Errorf("Cannot marshal to PEM: %v", err)
+		return fmt.Errorf("Cannot marshal to PEM: %w", err)
 	}
 	c.CertPEM = caPEM
 	c.PrivKeyPEM = privKeyPEM
@@ -200,11 +200,11 @@ func getCACertificate() (*CertificateGroup, error) {
 	}
 	err = certificateBundle.CreatePem()
 	if err != nil {
-		return nil, fmt.Errorf("Cannot encode certificate: %v", err)
+		return nil, fmt.Errorf("Cannot encode certificate: %w", err)
 	}
 	err = certificateBundle.parseSignedCertificate()
 	if err != nil {
-		return nil, fmt.Errorf("Cannot parse PEM certificate: %v", err)
+		return nil, fmt.Errorf("Cannot parse PEM certificate: %w", err)
 	}
 
 	// Just pushed the signed cert, so PubkeyAlgo is present on the cert
@@ -215,14 +215,14 @@ func getCACertificate() (*CertificateGroup, error) {
 func createKeyAndCSR(cert *x509.Certificate, caCert *CertificateGroup) (*CertificateGroup, error) {
 	certKey, err := caCert.GetNewKey()
 	if err != nil {
-		return nil, fmt.Errorf("Cannot generate cert Key: %v", err)
+		return nil, fmt.Errorf("Cannot generate cert Key: %w", err)
 	}
 
 	// sign the cert by the CA
 	certBytes, err := x509.CreateCertificate(
 		rand.Reader, cert, caCert.cert, certKey.Public(), caCert.privKey)
 	if err != nil {
-		return nil, fmt.Errorf("cannot sign certificate: %v", err)
+		return nil, fmt.Errorf("cannot sign certificate: %w", err)
 	}
 
 	certificateBundle := CertificateGroup{
@@ -232,12 +232,12 @@ func createKeyAndCSR(cert *x509.Certificate, caCert *CertificateGroup) (*Certifi
 	}
 	err = certificateBundle.CreatePem()
 	if err != nil {
-		return nil, fmt.Errorf("Cannot encode certificate: %v", err)
+		return nil, fmt.Errorf("Cannot encode certificate: %w", err)
 	}
 
 	err = certificateBundle.parseSignedCertificate()
 	if err != nil {
-		return nil, fmt.Errorf("Cannot parse PEM certificate: %v", err)
+		return nil, fmt.Errorf("Cannot parse PEM certificate: %w", err)
 	}
 	return &certificateBundle, nil
 }


### PR DESCRIPTION
This PR introduce lint and goimports capabilities into `Makefile`:

**Add**:
 - _imports_ which applies `goimports` command 
 -  _lint_ run `golanci-lint`
 - _fast-build_ target to be used during development. 

**Mod**:
_build_ target: add _imports_ to _build_ target.
*Remark*: the _lint_ has not been yet added to _build_ target because we need to decide which linter we keep. Some linter may produce false-positive or irrelevant errors