### PR TITLE
Fix: kind workflow ignores condition error

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -34,7 +34,7 @@ jobs:
           IMG=flotta-operator:latest make docker-build
           kind load docker-image flotta-operator:latest
           timeout 2m make deploy IMG=flotta-operator TARGET=kind || retVal=$?
-          if [ $retVal -ne 124 ]; then
+          if [[ -n "$retVal" && $retVal -ne 124 ]]; then
             echo "Make run failed"; exit 1
           fi
           kubectl wait --timeout=120s --for=condition=Ready pods --all -n flotta


### PR DESCRIPTION
The condition:
```
timeout 1m make deploy IMG=flotta-operator || retVal=$?
if [ $retVal -ne 124 ];
 then
    echo "Make run failed"; exit 1
fi
```
produced the following error in the logs when the build passes successfully:
`-ne: unary operator expected`

This error was caused since we should wrap the condition with one more `[]` and also check if `$retVal` is set before we check if his value is not 124. 
Therefore, the solution is to replace the condition with: `if [[ -n $retVal && $retVal -ne 124 ]]; then`
 
Signed-off-by: arielireni <aireni@redhat.com>