### PR TITLE
Change Flotta deployment labels

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    app: flotta-controller-manager
     openshift.io/cluster-monitoring: "true"
   name: system
 ---
@@ -13,16 +13,16 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    app: flotta-controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app: flotta-controller-manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        app: flotta-controller-manager
     spec:
       securityContext:
         runAsNonRoot: true
@@ -70,7 +70,7 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    app: flotta-controller-manager
 spec:
   ports:
     - name: yggds
@@ -78,5 +78,5 @@ spec:
       port: 8043
       targetPort: yggds
   selector:
-    control-plane: controller-manager
+    app: flotta-controller-manager
   type: ClusterIP

--- a/config/ocp/prometheus/monitor.yaml
+++ b/config/ocp/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    app: flotta-controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app: flotta-controller-manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    app: flotta-controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -15,4 +15,4 @@ spec:
     port: 8080
     targetPort: metrics
   selector:
-    control-plane: controller-manager
+    app: flotta-controller-manager

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -10,4 +10,4 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    control-plane: controller-manager
+    app: flotta-controller-manager


### PR DESCRIPTION
Changed Flotta deployment labels in order to avoid duplications of operators using the label `control-plane: controller-manager` for pods that deployed in the same namespace.

Signed-off-by: arielireni <aireni@redhat.com>