### PR TITLE
#24 Use OCP image for rbac side car

### DIFF
--- a/config/base/manager_auth_proxy_patch.yaml
+++ b/config/base/manager_auth_proxy_patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/ocp/kustomization.yaml
+++ b/config/ocp/kustomization.yaml
@@ -9,7 +9,10 @@ namespace: flotta
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
 namePrefix: flotta-operator-
-
+images:
+- name: "gcr.io/kubebuilder/kube-rbac-proxy"
+  newName: "registry.redhat.io/openshift4/ose-kube-rbac-proxy"
+  newTag: "v4.9.0"
 resources:
   - ../base
   - network/route.yaml


### PR DESCRIPTION
This commit to use the OCP proxy rbac image when generating manifests with ocp target