### PR TITLE
Add env var to change test image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ VERSION ?= 0.0.1
 
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
 IMAGE_TAG_BASE ?= project-flotta.io/flotta-operator
+TEST_IMAGE ?= quay.io/project-flotta/edgedevice:latest
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
@@ -108,7 +109,7 @@ test: GINKGO_OPTIONS ?= --skip e2e
 test: manifests generate fmt vet test-fast ## Run tests.
 
 integration-test: ginkgo get-certs
-	$(DOCKER) pull quay.io/project-flotta/edgedevice
+	$(DOCKER) pull $(TEST_IMAGE)
 	$(GINKGO) -focus=$(FOCUS) run test/e2e
 
 TEST_PACKAGES := ./...

--- a/test/e2e/edgedevice_test.go
+++ b/test/e2e/edgedevice_test.go
@@ -44,7 +44,7 @@ var localTestCertificates = []string{
 var edgeDeviceResource = schema.GroupVersionResource{Group: "management.project-flotta.io", Version: "v1alpha1", Resource: "edgedevices"}
 
 const (
-	EdgeDeviceImage string = "quay.io/project-flotta/edgedevice"
+	EdgeDeviceImage string = "quay.io/project-flotta/edgedevice:latest"
 	Namespace       string = "default" // the namespace where flotta operator is running
 	waitTimeout     int    = 120
 	sleepInterval   int    = 2
@@ -246,8 +246,12 @@ func (e *edgeDeviceDocker) waitForDevice(cond func() bool) error {
 // can be used to execute just before the registration happens. The main use
 // case is to add something needed for the test, like network-latency.
 func (e *edgeDeviceDocker) Register(cmds ...string) error {
+	image := EdgeDeviceImage
+	if name, exists := os.LookupEnv("TEST_IMAGE"); exists {
+		image = name
+	}
 	ctx := context.Background()
-	resp, err := e.cli.ContainerCreate(ctx, &container.Config{Image: EdgeDeviceImage}, &container.HostConfig{Privileged: true, ExtraHosts: []string{"project-flotta.io:172.17.0.1"}}, nil, nil, e.name)
+	resp, err := e.cli.ContainerCreate(ctx, &container.Config{Image: image}, &container.HostConfig{Privileged: true, ExtraHosts: []string{"project-flotta.io:172.17.0.1"}}, nil, nil, e.name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add TEST_IMAGE_TAG env var to change the image tag of the edgedevice
docker image test.

Signed-off-by: Ondra Machacek <omachace@redhat.com>