### PR TITLE
Enrol: Fix typos

### DIFF
--- a/docs/design/http_api_swagger.md
+++ b/docs/design/http_api_swagger.md
@@ -473,7 +473,7 @@ Status: Internal Server Error
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | features | [EnrolmentInfoFeatures](#enrolment-info-features)| `EnrolmentInfoFeatures` |  | |  |  |
-| target-namespace | string| `string` |  | `"default"`|  |  |
+| target_namespace | string| `string` |  | `"default"`|  |  |
 
 
 

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -262,9 +262,13 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 		if err != nil {
 			return operations.NewPostDataMessageForDeviceBadRequest()
 		}
-		logger.V(1).Info("received registration info", "content", enrolmentInfo)
+		logger.V(1).Info("received enrolment info", "content", enrolmentInfo)
+		ns := h.initialNamespace
+		if enrolmentInfo.TargetNamespace != nil {
+			ns = *enrolmentInfo.TargetNamespace
+		}
 
-		_, err = h.deviceRepository.Read(ctx, deviceID, *enrolmentInfo.TargetNamespace)
+		_, err = h.deviceRepository.Read(ctx, deviceID, ns)
 		if err == nil {
 			// Device is already created.
 			return operations.NewPostDataMessageForDeviceAlreadyReported()
@@ -290,7 +294,7 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 				Namespace: h.initialNamespace,
 			},
 			Spec: v1alpha1.EdgeDeviceSignedRequestSpec{
-				TargetNamespace: *enrolmentInfo.TargetNamespace,
+				TargetNamespace: ns,
 				Approved:        false,
 				Features: &v1alpha1.Features{
 					Hardware: hardware.MapHardware(enrolmentInfo.Features.Hardware),

--- a/internal/yggdrasil/yggdrasil_integration_test.go
+++ b/internal/yggdrasil/yggdrasil_integration_test.go
@@ -2496,6 +2496,27 @@ var _ = Describe("Yggdrasil", func() {
 				targetNamespace = "fooNS"
 			)
 
+			It("Empty enrolement information does not crash", func() {
+				// given
+				edgeDeviceRepoMock.EXPECT().
+					Read(gomock.Any(), deviceName, testNamespace).
+					Return(device, nil).
+					Times(1)
+
+				params := api.PostDataMessageForDeviceParams{
+					DeviceID: deviceName,
+					Message: &models.Message{
+						Directive: directiveName,
+					},
+				}
+
+				// when
+				res := handler.PostDataMessageForDevice(deviceCtx, params)
+
+				// then
+				Expect(res).To(BeAssignableToTypeOf(&api.PostDataMessageForDeviceAlreadyReported{}))
+			})
+
 			It("It's already created", func() {
 				// given
 				edgeDeviceRepoMock.EXPECT().

--- a/models/enrolment_info.go
+++ b/models/enrolment_info.go
@@ -20,7 +20,7 @@ type EnrolmentInfo struct {
 	Features *EnrolmentInfoFeatures `json:"features,omitempty"`
 
 	// target namespace
-	TargetNamespace *string `json:"target-namespace,omitempty"`
+	TargetNamespace *string `json:"target_namespace,omitempty"`
 }
 
 // Validate validates this enrolment info

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -426,7 +426,7 @@ func init() {
             }
           }
         },
-        "target-namespace": {
+        "target_namespace": {
           "type": "string",
           "default": "default"
         }
@@ -1486,7 +1486,7 @@ func init() {
             }
           }
         },
-        "target-namespace": {
+        "target_namespace": {
           "type": "string",
           "default": "default"
         }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -452,7 +452,7 @@ definitions:
             type: string
           hardware:
             $ref: '#/definitions/hardware-info'
-      target-namespace:
+      target_namespace:
         type: string
         default: "default"
 


### PR DESCRIPTION
Fix some logs messages.
Fix swagger definition to be correct.
Check ns namespace just if enrol info is empty.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>