### PR TITLE
Fix nullPointer issue

### DIFF
--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -277,7 +277,7 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 		edsr, err := h.edgedeviceSignedRequestRepository.Read(ctx, deviceID, h.initialNamespace)
 		if err == nil {
 			// Is already created, but not approved
-			if edsr.Spec.TargetNamespace != *enrolmentInfo.TargetNamespace {
+			if edsr.Spec.TargetNamespace != ns {
 				_, err = h.deviceRepository.Read(ctx, deviceID, edsr.Spec.TargetNamespace)
 				if err == nil {
 					// Device is already created.


### PR DESCRIPTION
Forgot to fix this one on 6944701464908b31cf99914bb5b04206409688dd, the
enrolmentInfo.TargetNamespace can be nil, so there is no default option
at all.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>