### PR TITLE
Registration: set correct namespace

### DIFF
--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -364,7 +364,7 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 			return operations.NewPostDataMessageForDeviceForbidden()
 		}
 
-		cert, err := h.mtlsConfig.SignCSR(registrationInfo.CertificateRequest, deviceID, h.initialNamespace)
+		cert, err := h.mtlsConfig.SignCSR(registrationInfo.CertificateRequest, deviceID, ns)
 		if err != nil {
 			return operations.NewPostDataMessageForDeviceBadRequest()
 		}

--- a/internal/yggdrasil/yggdrasil_integration_test.go
+++ b/internal/yggdrasil/yggdrasil_integration_test.go
@@ -2760,6 +2760,19 @@ var _ = Describe("Yggdrasil", func() {
 					return csrCertificate
 				}
 
+				getCert := func(PayloadContent interface{}) *x509.Certificate {
+					content, ok := PayloadContent.(models.RegistrationResponse)
+					Expect(ok).To(BeTrue())
+
+					block, rest := pem.Decode([]byte(content.Certificate))
+					Expect(block).NotTo(BeNil())
+					Expect(rest).NotTo(BeNil())
+
+					cert, err := x509.ParseCertificate(block.Bytes)
+					Expect(err).NotTo(HaveOccurred())
+					return cert
+				}
+
 				var givenCert string
 
 				BeforeEach(func() {
@@ -2883,6 +2896,11 @@ var _ = Describe("Yggdrasil", func() {
 					data, ok := res.(*operations.PostDataMessageForDeviceOK)
 					Expect(ok).To(BeTrue())
 					Expect(data.Payload.Content).NotTo(BeNil())
+
+					cert := getCert(data.Payload.Content)
+					Expect(cert.Subject.CommonName).To(Equal("foo"))
+					Expect(cert.Subject.OrganizationalUnit).To(HaveLen(1))
+					Expect(cert.Subject.OrganizationalUnit).To(ContainElement("test-ns"))
 				})
 
 				It("Device register for first time, but EDSR says another namespace", func() {
@@ -2944,6 +2962,11 @@ var _ = Describe("Yggdrasil", func() {
 					data, ok := res.(*operations.PostDataMessageForDeviceOK)
 					Expect(ok).To(BeTrue())
 					Expect(data.Payload.Content).NotTo(BeNil())
+
+					cert := getCert(data.Payload.Content)
+					Expect(cert.Subject.CommonName).To(Equal("foo"))
+					Expect(cert.Subject.OrganizationalUnit).To(HaveLen(1))
+					Expect(cert.Subject.OrganizationalUnit).To(ContainElement("otherNS"))
 				})
 
 				It("Device is already register, and send a CSR to renew", func() {
@@ -2986,6 +3009,11 @@ var _ = Describe("Yggdrasil", func() {
 					data, ok := res.(*operations.PostDataMessageForDeviceOK)
 					Expect(ok).To(BeTrue())
 					Expect(data.Payload.Content).NotTo(BeNil())
+
+					cert := getCert(data.Payload.Content)
+					Expect(cert.Subject.CommonName).To(Equal("foo"))
+					Expect(cert.Subject.OrganizationalUnit).To(HaveLen(1))
+					Expect(cert.Subject.OrganizationalUnit).To(ContainElement("test-ns"))
 				})
 
 				It("cannot patch device", func() {


### PR DESCRIPTION
When signing the CSR given by the device, it signs correctly, but the
namespace set on the function was `h.initialNamesapce`. When device try
to retrieve the config,  it retuns 404 that device cannot be found,
because the certificate does not contain the valid metadata.

This commits change the namespace to the correct one, and adds a
specific check on the unittest to avoid this kind of issues in future.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>