### PR TITLE
Controller: remove edgedevice signed request when device is deleted

### DIFF
--- a/internal/repository/edgedevicesignedrequest/edgedevicesignedrequest.go
+++ b/internal/repository/edgedevicesignedrequest/edgedevicesignedrequest.go
@@ -13,6 +13,7 @@ type Repository interface {
 	Create(ctx context.Context, edgedeviceSignedRequest *v1alpha1.EdgeDeviceSignedRequest) error
 	PatchStatus(ctx context.Context, edgedeviceSignedRequest *v1alpha1.EdgeDeviceSignedRequest, patch *client.Patch) error
 	Patch(ctx context.Context, old *v1alpha1.EdgeDeviceSignedRequest, new *v1alpha1.EdgeDeviceSignedRequest) error
+	Delete(ctx context.Context, obj *v1alpha1.EdgeDeviceSignedRequest) error
 }
 
 type EdgedeviceSignedRequestRepository struct {
@@ -40,4 +41,8 @@ func (esr *EdgedeviceSignedRequestRepository) PatchStatus(ctx context.Context, e
 func (esr *EdgedeviceSignedRequestRepository) Patch(ctx context.Context, old *v1alpha1.EdgeDeviceSignedRequest, new *v1alpha1.EdgeDeviceSignedRequest) error {
 	patch := client.MergeFrom(old)
 	return esr.client.Patch(ctx, new, patch)
+}
+
+func (esr *EdgedeviceSignedRequestRepository) Delete(ctx context.Context, obj *v1alpha1.EdgeDeviceSignedRequest) error {
+	return esr.client.Delete(ctx, obj)
 }

--- a/internal/repository/edgedevicesignedrequest/mock_edgedeviceSignedRequest.go
+++ b/internal/repository/edgedevicesignedrequest/mock_edgedeviceSignedRequest.go
@@ -50,6 +50,20 @@ func (mr *MockRepositoryMockRecorder) Create(arg0, arg1 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockRepository)(nil).Create), arg0, arg1)
 }
 
+// Delete mocks base method.
+func (m *MockRepository) Delete(arg0 context.Context, arg1 *v1alpha1.EdgeDeviceSignedRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockRepositoryMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockRepository)(nil).Delete), arg0, arg1)
+}
+
 // Patch mocks base method.
 func (m *MockRepository) Patch(arg0 context.Context, arg1, arg2 *v1alpha1.EdgeDeviceSignedRequest) error {
 	m.ctrl.T.Helper()

--- a/main.go
+++ b/main.go
@@ -210,12 +210,14 @@ func main() {
 	}
 
 	if err = (&controllers.EdgeDeviceReconciler{
-		Client:                  mgr.GetClient(),
-		Scheme:                  mgr.GetScheme(),
-		EdgeDeviceRepository:    edgeDeviceRepository,
-		Claimer:                 claimer,
-		ObcAutoCreate:           Config.EnableObcAutoCreation,
-		MaxConcurrentReconciles: int(Config.MaxConcurrentReconciles),
+		Client:                            mgr.GetClient(),
+		Scheme:                            mgr.GetScheme(),
+		EdgeDeviceRepository:              edgeDeviceRepository,
+		EdgeDeviceSignedRequestRepository: edgeDeviceSignedRequestRepository,
+		InitialDeviceNamespace:            initialDeviceNamespace,
+		Claimer:                           claimer,
+		ObcAutoCreate:                     Config.EnableObcAutoCreation,
+		MaxConcurrentReconciles:           int(Config.MaxConcurrentReconciles),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EdgeDevice")
 		os.Exit(1)


### PR DESCRIPTION
When the device is removed, the EdgeDevice Signed request is still
approved, but the controller will never create a new entry for device,
so it keeps in a loop of no option to re-register.

For now, if a device is deleted, the EDSR will also be deleted.

Fix ECOPROJECT-776

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>