### PR TITLE
Agent installation adding port option

### DIFF
--- a/hack/config.toml
+++ b/hack/config.toml
@@ -5,4 +5,4 @@ ca-root = ["/etc/pki/consumer/ca.pem"]
 path-prefix = "api/flotta-management/v1"
 protocol = "http"
 client-id = "$(cat /etc/machine-id)"
-server = "project-flotta.io:8043"
+server = "project-flotta.io:$FLOTTA_PORT"

--- a/hack/install-agent-dnf.sh.template
+++ b/hack/install-agent-dnf.sh.template
@@ -7,19 +7,23 @@ Usage: $0 OPTIONS
 This script installs Flotta agent component on RPM-compatible machine.
 OPTIONS:
    -h      Show this message
-   -i      IP address under which your Flotta operator API endpoint on port 8043 is accessible to the device.
-           When your KUBECONFIG is pointing to cluster with Flotta operator deployed, you can run
+   -i      IP address under which your Flotta edge API endpoint is accessible to the device.
+           For testing, when your KUBECONFIG is pointing to cluster with Flotta operator deployed, you can run
 
            kubectl port-forward service/flotta-operator-controller-manager -n flotta 8043 --address 0.0.0.0
 
            to make the Flotta API accessible from your machine
+   -p      Port to connect to Flotta API, default 8043
 EOF
 }
 
-while getopts "i:h:" option; do
+FLOTTA_PORT=8043
+
+while getopts "i:h:p:" option; do
     case "${option}"
     in
         i) FLOTTA_API_IP=${OPTARG};;
+        p) FLOTTA_PORT=${OPTARG};;
         h)
             usage
             exit 0
@@ -36,7 +40,6 @@ if [[ -z $FLOTTA_API_IP ]]; then
     usage
     exit 1
 fi
-
 
 curl https://copr.fedorainfracloud.org/coprs/project-flotta/flotta/repo/fedora-35/project-flotta-flotta-fedora-35.repo -o /etc/yum.repos.d/project-flotta.repo
 

--- a/hack/install-agent-rpm-ostree.sh.template
+++ b/hack/install-agent-rpm-ostree.sh.template
@@ -7,19 +7,19 @@ Usage: $0 OPTIONS
 This script installs Flotta agent component on RPM-compatible machine.
 OPTIONS:
    -h      Show this message
-   -i      IP address under which your Flotta operator API endpoint on port 8043 is accessible to the device.
-           When your KUBECONFIG is pointing to cluster with Flotta operator deployed, you can run
+   -i      IP address under which your Flotta edge API endpoint is accessible to the device.
+           For testing, when your KUBECONFIG is pointing to cluster with Flotta operator deployed, you can run
 
            kubectl port-forward service/flotta-operator-controller-manager -n flotta 8043 --address 0.0.0.0
-
-           to make the Flotta API accessible from your machine
+   -p      Port to connect to Flotta API, default 8043
 EOF
 }
 
-while getopts "i:h:" option; do
+while getopts "i:h:p:" option; do
     case "${option}"
     in
         i) FLOTTA_API_IP=${OPTARG};;
+        p) FLOTTA_PORT=${OPTARG};;
         h)
             usage
             exit 0


### PR DESCRIPTION
When running agent script always uses port 8043, with this patch port
8043 is set by default, but you can run with a specific argument:

```
$ hack/install-agent-dnf.sh -i 192.168.2.10 -p 443
```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>