### PR TITLE
Remove unused make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ lint: ## Check if the go code is properly written, rules are in .golangci.yml
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: ## Run tests.
 test: GINKGO_OPTIONS ?= --skip e2e
-test: manifests generate fmt vet imports test-fast ## Run tests.
+test: manifests generate fmt vet imports test-fast
 
 integration-test: ginkgo get-certs
 ifeq ($(SKIP_TEST_IMAGE_PULL), false)


### PR DESCRIPTION
There was a duplication for defining the test target, which caused dupication in the `make help` output for the test target.

```
→ make help

Usage:
  make <target>

General
  help                  Display this help.

Development
  manifests             Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
  generate              Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
  fmt                   Run go fmt against code.
  vet                   Run go vet against code.
  gosec                 Run gosec locally
  imports               fix and format go imports
  lint                  Check if the go code is properly written, rules are in .golangci.yml 
  test                  Run tests.
  test                  Run tests.
```

Therefore, after removing the unused definition, we'll receive only one line for the test target in the `make help` output.

Signed-off-by: arielireni <aireni@redhat.com>