### PR TITLE
Added metrics for authN

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -14,6 +14,8 @@ const (
 	EdgeDeviceFailedRegistrationQuery     = "flotta_operator_edge_devices_failed_registration"
 	EdgeDeviceUnregistrationQuery         = "flotta_operator_edge_devices_unregistration"
 	EdgeDeviceHeartbeatQuery              = "flotta_operator_edge_devices_heartbeat"
+	EdgeDeviceFailedAuthentication        = "flotta_operator_edge_devices_failed_authentication"
+	EdgeDeviceInvalidOwner                = "flotta_operator_edge_devices_invalid_owner"
 )
 
 var (
@@ -35,6 +37,20 @@ var (
 			Help: "Number of unregistered EdgeDevices",
 		},
 	)
+
+	failedAuthenticationCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: EdgeDeviceFailedAuthentication,
+			Help: "Counts the number of devices that failed to authenticate",
+		},
+	)
+
+	invalidOwnerCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: EdgeDeviceInvalidOwner,
+			Help: "Counts the number of times a device ID mismatches the ID stored in the context",
+		},
+	)
 )
 
 func init() {
@@ -43,6 +59,8 @@ func init() {
 		registeredEdgeDevices,
 		failedToCompleteRegistrationEdgeDevices,
 		unregisteredEdgeDevices,
+		failedAuthenticationCounter,
+		invalidOwnerCounter,
 	)
 }
 
@@ -56,6 +74,8 @@ type Metrics interface {
 	RecordEdgeDevicePresence(namespace, name string)
 	RemoveDeviceCounter(namespace, name string)
 	RegisterDeviceCounter(namespace string, name string)
+	IncEdgeDeviceFailedAuthenticationCounter()
+	IncEdgeDeviceInvalidOwnerCounter()
 }
 
 func New() Metrics {
@@ -85,6 +105,14 @@ func (m *metricsImpl) IncEdgeDeviceFailedRegistration() {
 }
 func (m *metricsImpl) IncEdgeDeviceUnregistration() {
 	unregisteredEdgeDevices.Inc()
+}
+
+func (m *metricsImpl) IncEdgeDeviceFailedAuthenticationCounter() {
+	failedAuthenticationCounter.Inc()
+}
+
+func (m *metricsImpl) IncEdgeDeviceInvalidOwnerCounter() {
+	invalidOwnerCounter.Inc()
 }
 
 func (m *metricsImpl) RemoveDeviceCounter(namespace, name string) {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -16,6 +16,8 @@ const (
 	numberOfEdgeDevicesSuccessfulRegisteredValue = 3
 	numberOfEdgeDevicesFailedToRegisterValue     = 1
 	numberOfEdgeDevicesUnregisteredValue         = 2
+	numberOfEdgeDevicesFailedAuthentication      = 1
+	numberOfEdgeDevicesInvalidOwner              = 1
 )
 
 func TestMetrics(t *testing.T) {
@@ -170,6 +172,24 @@ var _ = Describe("Metrics", func() {
 			}
 
 			Fail("Metric not found")
+		})
+
+		It("correctly detects when a device fails to authenticate", func() {
+			for i := 0; i < numberOfEdgeDevicesFailedAuthentication; i++ {
+				m.IncEdgeDeviceFailedAuthenticationCounter()
+			}
+
+			//then
+			validateMetric(metrics.EdgeDeviceFailedAuthentication, numberOfEdgeDevicesFailedAuthentication)
+		})
+
+		It("correctly detects when a device fails to authenticate", func() {
+			for i := 0; i < numberOfEdgeDevicesInvalidOwner; i++ {
+				m.IncEdgeDeviceInvalidOwnerCounter()
+			}
+
+			//then
+			validateMetric(metrics.EdgeDeviceInvalidOwner, numberOfEdgeDevicesInvalidOwner)
 		})
 	})
 })

--- a/internal/metrics/mock_metrics_api.go
+++ b/internal/metrics/mock_metrics_api.go
@@ -33,6 +33,18 @@ func (m *MockMetrics) EXPECT() *MockMetricsMockRecorder {
 	return m.recorder
 }
 
+// IncEdgeDeviceFailedAuthenticationCounter mocks base method.
+func (m *MockMetrics) IncEdgeDeviceFailedAuthenticationCounter() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IncEdgeDeviceFailedAuthenticationCounter")
+}
+
+// IncEdgeDeviceFailedAuthenticationCounter indicates an expected call of IncEdgeDeviceFailedAuthenticationCounter.
+func (mr *MockMetricsMockRecorder) IncEdgeDeviceFailedAuthenticationCounter() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncEdgeDeviceFailedAuthenticationCounter", reflect.TypeOf((*MockMetrics)(nil).IncEdgeDeviceFailedAuthenticationCounter))
+}
+
 // IncEdgeDeviceFailedRegistration mocks base method.
 func (m *MockMetrics) IncEdgeDeviceFailedRegistration() {
 	m.ctrl.T.Helper()
@@ -43,6 +55,18 @@ func (m *MockMetrics) IncEdgeDeviceFailedRegistration() {
 func (mr *MockMetricsMockRecorder) IncEdgeDeviceFailedRegistration() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncEdgeDeviceFailedRegistration", reflect.TypeOf((*MockMetrics)(nil).IncEdgeDeviceFailedRegistration))
+}
+
+// IncEdgeDeviceInvalidOwnerCounter mocks base method.
+func (m *MockMetrics) IncEdgeDeviceInvalidOwnerCounter() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IncEdgeDeviceInvalidOwnerCounter")
+}
+
+// IncEdgeDeviceInvalidOwnerCounter indicates an expected call of IncEdgeDeviceInvalidOwnerCounter.
+func (mr *MockMetricsMockRecorder) IncEdgeDeviceInvalidOwnerCounter() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncEdgeDeviceInvalidOwnerCounter", reflect.TypeOf((*MockMetrics)(nil).IncEdgeDeviceInvalidOwnerCounter))
 }
 
 // IncEdgeDeviceSuccessfulRegistration mocks base method.

--- a/internal/yggdrasil/yggdrasil.go
+++ b/internal/yggdrasil/yggdrasil.go
@@ -142,6 +142,7 @@ func (h *Handler) getNamespace(ctx context.Context) string {
 func (h *Handler) GetControlMessageForDevice(ctx context.Context, params yggdrasil.GetControlMessageForDeviceParams) middleware.Responder {
 	deviceID := params.DeviceID
 	if !IsOwnDevice(ctx, deviceID) {
+		h.metrics.IncEdgeDeviceInvalidOwnerCounter()
 		return operations.NewGetControlMessageForDeviceForbidden()
 	}
 	logger := log.FromContext(ctx, "DeviceID", deviceID)
@@ -172,6 +173,7 @@ func (h *Handler) GetControlMessageForDevice(ctx context.Context, params yggdras
 func (h *Handler) GetDataMessageForDevice(ctx context.Context, params yggdrasil.GetDataMessageForDeviceParams) middleware.Responder {
 	deviceID := params.DeviceID
 	if !IsOwnDevice(ctx, deviceID) {
+		h.metrics.IncEdgeDeviceInvalidOwnerCounter()
 		return operations.NewGetDataMessageForDeviceForbidden()
 	}
 	logger := log.FromContext(ctx, "DeviceID", deviceID)
@@ -214,6 +216,7 @@ func (h *Handler) GetDataMessageForDevice(ctx context.Context, params yggdrasil.
 func (h *Handler) PostControlMessageForDevice(ctx context.Context, params yggdrasil.PostControlMessageForDeviceParams) middleware.Responder {
 	deviceID := params.DeviceID
 	if !IsOwnDevice(ctx, deviceID) {
+		h.metrics.IncEdgeDeviceInvalidOwnerCounter()
 		return operations.NewPostDataMessageForDeviceForbidden()
 	}
 	return operations.NewPostControlMessageForDeviceOK()
@@ -228,6 +231,7 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 		break
 	default:
 		if !IsOwnDevice(ctx, deviceID) {
+			h.metrics.IncEdgeDeviceInvalidOwnerCounter()
 			return operations.NewPostDataMessageForDeviceForbidden()
 		}
 	}

--- a/internal/yggdrasil/yggdrasil_integration_test.go
+++ b/internal/yggdrasil/yggdrasil_integration_test.go
@@ -142,7 +142,9 @@ var _ = Describe("Yggdrasil", func() {
 		)
 
 		It("cannot retrieve another device", func() {
+			// given
 			ctx := context.WithValue(context.TODO(), AuthzKey, mtls.RequestAuthVal{CommonName: "bar"})
+			metricsMock.EXPECT().IncEdgeDeviceInvalidOwnerCounter().Times(1)
 
 			// when
 			res := handler.GetControlMessageForDevice(ctx, params)
@@ -152,6 +154,9 @@ var _ = Describe("Yggdrasil", func() {
 		})
 
 		It("cannot retrieve device with empty context", func() {
+			// given
+			metricsMock.EXPECT().IncEdgeDeviceInvalidOwnerCounter().Times(1)
+
 			// when
 			res := handler.GetControlMessageForDevice(context.TODO(), params)
 
@@ -313,6 +318,8 @@ var _ = Describe("Yggdrasil", func() {
 		It("Trying to access with not owning device", func() {
 			// given
 			ctx := context.WithValue(context.TODO(), AuthzKey, mtls.RequestAuthVal{CommonName: "bar"})
+			metricsMock.EXPECT().IncEdgeDeviceInvalidOwnerCounter().Times(1)
+
 			// when
 			res := handler.GetDataMessageForDevice(ctx, params)
 
@@ -321,6 +328,8 @@ var _ = Describe("Yggdrasil", func() {
 		})
 
 		It("Trying to access no context device", func() {
+			// given
+			metricsMock.EXPECT().IncEdgeDeviceInvalidOwnerCounter().Times(1)
 			// when
 			res := handler.GetDataMessageForDevice(context.TODO(), params)
 
@@ -2079,6 +2088,7 @@ var _ = Describe("Yggdrasil", func() {
 					Directive: "NOT VALID ONE",
 				},
 			}
+			metricsMock.EXPECT().IncEdgeDeviceInvalidOwnerCounter().Times(2)
 
 			// when
 			res := handler.PostDataMessageForDevice(ctx, params)
@@ -2103,6 +2113,7 @@ var _ = Describe("Yggdrasil", func() {
 						Directive: directiveName,
 					},
 				}
+				metricsMock.EXPECT().IncEdgeDeviceInvalidOwnerCounter().Times(1)
 
 				// when
 				res := handler.PostDataMessageForDevice(ctx, params)

--- a/main.go
+++ b/main.go
@@ -346,6 +346,7 @@ func main() {
 
 					authType := yggdrasilAPIHandler.GetAuthType(r, api)
 					if ok, err := mtls.VerifyRequest(r, authType, opts, CACertChain, yggdrasil.AuthzKey); !ok {
+						metricsObj.IncEdgeDeviceFailedAuthenticationCounter()
 						setupLog.V(0).Info("cannot verify request:", "authType", authType, "method", r.Method, "url", r.URL, "err", err)
 						w.WriteHeader(http.StatusUnauthorized)
 						return


### PR DESCRIPTION
* flotta_operator_edge_devices_failed_authentication: counts the number of
times a device fails to authenticate, such as invalid cert, expired
cert, no cert.

* flotta_operator_edge_devices_invalid_owner: counts the number of times
  a device ID mismatches the ID stored in the context of the request.

