### PR TITLE
Remove usage of finalizers on the EdgeDevice

### DIFF
--- a/internal/common/repository/edgedevice/edgedevice.go
+++ b/internal/common/repository/edgedevice/edgedevice.go
@@ -20,7 +20,6 @@ type Repository interface {
 	Patch(ctx context.Context, old, new *v1alpha1.EdgeDevice) error
 	ListForSelector(ctx context.Context, selector *metav1.LabelSelector, namespace string) ([]v1alpha1.EdgeDevice, error)
 	ListForWorkload(ctx context.Context, name string, namespace string) ([]v1alpha1.EdgeDevice, error)
-	RemoveFinalizer(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice, finalizer string) error
 	UpdateLabels(ctx context.Context, device *v1alpha1.EdgeDevice, labels map[string]string) error
 }
 
@@ -77,25 +76,6 @@ func (r CRRepository) ListForWorkload(ctx context.Context, name string, namespac
 	}
 
 	return edl.Items, nil
-}
-
-func (r *CRRepository) RemoveFinalizer(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice, finalizer string) error {
-	cp := edgeDevice.DeepCopy()
-
-	var finalizers []string
-	for _, f := range cp.Finalizers {
-		if f != finalizer {
-			finalizers = append(finalizers, f)
-		}
-	}
-	cp.Finalizers = finalizers
-
-	err := r.Patch(ctx, edgeDevice, cp)
-	if err == nil {
-		edgeDevice.Finalizers = cp.Finalizers
-	}
-
-	return nil
 }
 
 func (r *CRRepository) UpdateLabels(ctx context.Context, device *v1alpha1.EdgeDevice, labels map[string]string) error {

--- a/internal/common/repository/edgedevice/mock_edgedevice.go
+++ b/internal/common/repository/edgedevice/mock_edgedevice.go
@@ -125,20 +125,6 @@ func (mr *MockRepositoryMockRecorder) Read(arg0, arg1, arg2 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRepository)(nil).Read), arg0, arg1, arg2)
 }
 
-// RemoveFinalizer mocks base method.
-func (m *MockRepository) RemoveFinalizer(arg0 context.Context, arg1 *v1alpha1.EdgeDevice, arg2 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveFinalizer", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveFinalizer indicates an expected call of RemoveFinalizer.
-func (mr *MockRepositoryMockRecorder) RemoveFinalizer(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFinalizer", reflect.TypeOf((*MockRepository)(nil).RemoveFinalizer), arg0, arg1, arg2)
-}
-
 // UpdateLabels mocks base method.
 func (m *MockRepository) UpdateLabels(arg0 context.Context, arg1 *v1alpha1.EdgeDevice, arg2 map[string]string) error {
 	m.ctrl.T.Helper()

--- a/internal/edgeapi/backend/k8s/backend.go
+++ b/internal/edgeapi/backend/k8s/backend.go
@@ -42,6 +42,9 @@ func NewBackend(repository RepositoryFacade, assembler *ConfigurationAssembler,
 func (b *backend) GetRegistrationStatus(ctx context.Context, name, namespace string) (backendapi.RegistrationStatus, error) {
 	edgeDevice, err := b.repository.GetEdgeDevice(ctx, name, namespace)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return backendapi.Unregistered, nil
+		}
 		return backendapi.Unknown, err
 	}
 

--- a/internal/edgeapi/backend/k8s/backend.go
+++ b/internal/edgeapi/backend/k8s/backend.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/project-flotta/flotta-operator/api/v1alpha1"
-	"github.com/project-flotta/flotta-operator/internal/common/utils"
 	backendapi "github.com/project-flotta/flotta-operator/internal/edgeapi/backend"
 	"github.com/project-flotta/flotta-operator/internal/edgeapi/hardware"
 	"github.com/project-flotta/flotta-operator/models"
@@ -20,9 +19,6 @@ import (
 )
 
 const (
-	YggdrasilConnectionFinalizer = "yggdrasil-connection-finalizer"
-	YggdrasilWorkloadFinalizer   = "yggdrasil-workload-finalizer"
-
 	AuthzKey mtls.RequestAuthKey = "APIAuthzkey"
 )
 
@@ -49,17 +45,11 @@ func (b *backend) GetRegistrationStatus(ctx context.Context, name, namespace str
 		return backendapi.Unknown, err
 	}
 
-	if edgeDevice.DeletionTimestamp == nil || utils.HasFinalizer(&edgeDevice.ObjectMeta, YggdrasilWorkloadFinalizer) {
-		return backendapi.Registered, nil
+	if edgeDevice.DeletionTimestamp != nil {
+		return backendapi.Unregistered, nil
 	}
 
-	if utils.HasFinalizer(&edgeDevice.ObjectMeta, YggdrasilConnectionFinalizer) {
-		err = b.repository.RemoveEdgeDeviceFinalizer(ctx, edgeDevice, YggdrasilConnectionFinalizer)
-		if err != nil {
-			return backendapi.Registered, err
-		}
-	}
-	return backendapi.Unregistered, nil
+	return backendapi.Registered, nil
 }
 
 func (b *backend) GetConfiguration(ctx context.Context, name, namespace string) (*models.DeviceConfigurationMessage, error) {
@@ -69,14 +59,6 @@ func (b *backend) GetConfiguration(ctx context.Context, name, namespace string) 
 		return nil, err
 	}
 
-	if edgeDevice.DeletionTimestamp != nil {
-		if utils.HasFinalizer(&edgeDevice.ObjectMeta, YggdrasilWorkloadFinalizer) {
-			err := b.repository.RemoveEdgeDeviceFinalizer(ctx, edgeDevice, YggdrasilWorkloadFinalizer)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
 	return b.assembler.GetDeviceConfiguration(ctx, edgeDevice, logger)
 }
 
@@ -170,7 +152,6 @@ func (b *backend) Register(ctx context.Context, name, namespace string, registra
 	logger := b.logger.With("DeviceID", name, "Namespace", namespace)
 	dvc, err := b.repository.GetEdgeDevice(ctx, name, namespace)
 	deviceCopy := dvc.DeepCopy()
-	deviceCopy.Finalizers = []string{YggdrasilConnectionFinalizer, YggdrasilWorkloadFinalizer}
 	for key, val := range hardware.MapLabels(registrationInfo.Hardware) {
 		deviceCopy.ObjectMeta.Labels[key] = val
 	}

--- a/internal/edgeapi/backend/k8s/mock_repository_facade.go
+++ b/internal/edgeapi/backend/k8s/mock_repository_facade.go
@@ -170,20 +170,6 @@ func (mr *MockRepositoryFacadeMockRecorder) PatchEdgeDeviceStatus(arg0, arg1, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchEdgeDeviceStatus", reflect.TypeOf((*MockRepositoryFacade)(nil).PatchEdgeDeviceStatus), arg0, arg1, arg2)
 }
 
-// RemoveEdgeDeviceFinalizer mocks base method.
-func (m *MockRepositoryFacade) RemoveEdgeDeviceFinalizer(arg0 context.Context, arg1 *v1alpha1.EdgeDevice, arg2 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveEdgeDeviceFinalizer", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveEdgeDeviceFinalizer indicates an expected call of RemoveEdgeDeviceFinalizer.
-func (mr *MockRepositoryFacadeMockRecorder) RemoveEdgeDeviceFinalizer(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveEdgeDeviceFinalizer", reflect.TypeOf((*MockRepositoryFacade)(nil).RemoveEdgeDeviceFinalizer), arg0, arg1, arg2)
-}
-
 // UpdateEdgeDeviceLabels mocks base method.
 func (m *MockRepositoryFacade) UpdateEdgeDeviceLabels(arg0 context.Context, arg1 *v1alpha1.EdgeDevice, arg2 map[string]string) error {
 	m.ctrl.T.Helper()

--- a/internal/edgeapi/backend/k8s/repository.go
+++ b/internal/edgeapi/backend/k8s/repository.go
@@ -19,7 +19,6 @@ type EdgeDeviceRepository interface {
 	PatchEdgeDeviceStatus(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice, patch *client.Patch) error
 	UpdateEdgeDeviceLabels(ctx context.Context, device *v1alpha1.EdgeDevice, labels map[string]string) error
 	PatchEdgeDevice(ctx context.Context, old, new *v1alpha1.EdgeDevice) error
-	RemoveEdgeDeviceFinalizer(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice, finalizer string) error
 }
 
 type EdgeDeviceSignedRequestRepository interface {
@@ -85,10 +84,6 @@ func (b *repositoryFacade) UpdateEdgeDeviceLabels(ctx context.Context, device *v
 
 func (b *repositoryFacade) PatchEdgeDevice(ctx context.Context, old, new *v1alpha1.EdgeDevice) error {
 	return b.deviceRepository.Patch(ctx, old, new)
-}
-
-func (b *repositoryFacade) RemoveEdgeDeviceFinalizer(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice, finalizer string) error {
-	return b.deviceRepository.RemoveFinalizer(ctx, edgeDevice, finalizer)
 }
 
 func (b *repositoryFacade) GetEdgeDeviceSignedRequest(ctx context.Context, name string, namespace string) (*v1alpha1.EdgeDeviceSignedRequest, error) {

--- a/internal/edgeapi/yggdrasil/yggdrasil_integration_test.go
+++ b/internal/edgeapi/yggdrasil/yggdrasil_integration_test.go
@@ -178,11 +178,16 @@ var _ = Describe("Yggdrasil", func() {
 				Return(nil, errorNotFound).
 				Times(1)
 
+			metricsMock.EXPECT().
+				IncEdgeDeviceUnregistration().
+				Times(1)
+
 			// when
 			res := handler.GetControlMessageForDevice(deviceCtx, params)
+			data := res.(*api.GetControlMessageForDeviceOK)
 
 			// then
-			Expect(res).To(Equal(operations.NewGetControlMessageForDeviceNotFound()))
+			Expect(data.Payload.Type).To(Equal("command"))
 		})
 
 		It("Cannot retrieve device", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/project-flotta/flotta-operator/api/v1alpha1"
 	managementv1alpha1 "github.com/project-flotta/flotta-operator/generated/clientset/versioned/typed/v1alpha1"
@@ -159,9 +160,10 @@ var _ = Describe("e2e", func() {
 			Expect(err).To(BeNil())
 
 			// then
-			stdout, err := device.Exec("ls /etc/yggdrasil/device/ | wc -l")
-			Expect(err).To(BeNil())
-			Expect(stdout).To(Equal("0"))
+			Eventually(func() (string, error) {
+				return device.Exec("ls /etc/yggdrasil/device/ | wc -l")
+			}).WithTimeout(180 * time.Second).Should(Equal("0"))
+
 		})
 
 		It("Unregister device with running workloads", func() {
@@ -179,12 +181,12 @@ var _ = Describe("e2e", func() {
 
 			// then
 			// properly cleaned ygg dir
-			stdout, err := device.Exec("ls /etc/yggdrasil/device/ | wc -l")
-			Expect(err).To(BeNil())
-			Expect(stdout).To(Equal("0"))
+			Eventually(func() (string, error) {
+				return device.Exec("ls /etc/yggdrasil/device/ | wc -l")
+			}).WithTimeout(180 * time.Second).Should(Equal("0"))
 
 			// no pods running
-			stdout, err = device.Exec("machinectl shell -q flotta@.host /usr/bin/podman ps --noheading | wc -l")
+			stdout, err := device.Exec("machinectl shell -q flotta@.host /usr/bin/podman ps --noheading | wc -l")
 			Expect(err).To(BeNil())
 			Expect(stdout).To(Equal("1")) // machinectl print one empty new line
 


### PR DESCRIPTION
This PR removes the need for `EdgeDevice` finalizers - device deregistration is signalled by `EdgeDevice` being not present in 
the cluster or having `DeletionTimestamp` set.

Follow-up for https://github.com/project-flotta/flotta-operator/pull/236#discussion_r885375844

Signed-off-by: Jakub Dzon <jdzon@redhat.com>