### PR TITLE
Makefile: add make run-http-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,9 @@ run: manifests pre-build ## Run a controller from your host.
 	$(Q) kubectl create ns $(FLOTTA_OPERATOR_NAMESPACE) 2> /dev/null || exit 0
 	OBC_AUTO_CREATE=false ENABLE_WEBHOOKS=false LOG_LEVEL=debug go run -mod=vendor ./main.go
 
+http-api-run: ## Run HTTP API in localhost
+	METRICS_ADDR=":8089" go run cmd/httpapi/main.go
+
 docker-build: ## Build docker image with the manager.
 	$(DOCKER) build -t ${IMG} .
 	$(DOCKER) build -f build/httpapi/Dockerfile -t ${HTTP_IMG} .

--- a/cmd/httpapi/main.go
+++ b/cmd/httpapi/main.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -222,7 +223,7 @@ func getRestConfig(kubeconfigPath string) (*rest.Config, error) {
 	if kubeconfigPath != "" {
 		return clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	}
-	return rest.InClusterConfig()
+	return ctrl.GetConfig()
 }
 
 func getClient(config *rest.Config, options client.Options) (client.Client, error) {


### PR DESCRIPTION
This change adds a new Makefile target to run the http-api in local
without running the container, the main use cases:

- Define a Kubeconfig to be able to retrieve the right config on the API.
- Set the metrics port in different port, to be able to run with the
  controller.

I know that this makefile target is super opinionated, so please feel
free to close this PR if adds 0 value to you.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>