### PR TITLE
Option to use remote backend

### DIFF
--- a/build/httpapi/Dockerfile
+++ b/build/httpapi/Dockerfile
@@ -16,6 +16,7 @@ COPY internal/edgeapi internal/edgeapi
 COPY models/ models/
 COPY pkg/ pkg/
 COPY restapi/ restapi/
+COPY backend/ backend/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -o flotta-edge-api main.go
 

--- a/internal/edgeapi/backend/factory/factory.go
+++ b/internal/edgeapi/backend/factory/factory.go
@@ -1,10 +1,16 @@
 package factory
 
 import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+	"time"
+
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/record"
 	kubeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	backendclient "github.com/project-flotta/flotta-operator/backend/client"
 	"github.com/project-flotta/flotta-operator/internal/common/repository/edgedevice"
 	"github.com/project-flotta/flotta-operator/internal/common/repository/edgedeviceset"
 	"github.com/project-flotta/flotta-operator/internal/common/repository/edgedevicesignedrequest"
@@ -12,33 +18,71 @@ import (
 	"github.com/project-flotta/flotta-operator/internal/common/storage"
 	"github.com/project-flotta/flotta-operator/internal/edgeapi/backend"
 	"github.com/project-flotta/flotta-operator/internal/edgeapi/backend/k8s"
+	"github.com/project-flotta/flotta-operator/internal/edgeapi/backend/remote"
 	"github.com/project-flotta/flotta-operator/internal/edgeapi/configmaps"
 	"github.com/project-flotta/flotta-operator/internal/edgeapi/devicemetrics"
 	"github.com/project-flotta/flotta-operator/internal/edgeapi/images"
 	"github.com/project-flotta/flotta-operator/internal/edgeapi/k8sclient"
 )
 
-func Create(initialDeviceNamespace string, client kubeclient.Client, logger *zap.SugaredLogger, eventRecorder record.EventRecorder) backend.EdgeDeviceBackend {
-	// For now just one implementation is supported
-	k8sClient := k8sclient.NewK8sClient(client)
+type Factory struct {
+	InitialDeviceNamespace string
+	Logger                 *zap.SugaredLogger
+	Client                 kubeclient.Client
+	EventRecorder          record.EventRecorder
+	TLSConfig              *tls.Config
+}
 
-	edgeDeviceSignedRequestRepository := edgedevicesignedrequest.NewEdgedeviceSignedRequestRepository(client)
-	edgeDeviceRepository := edgedevice.NewEdgeDeviceRepository(client)
-	edgeWorkloadRepository := edgeworkload.NewEdgeWorkloadRepository(client)
-	edgeDeviceSetRepository := edgedeviceset.NewEdgeDeviceSetRepository(client)
+func (f *Factory) Create(remoteBackendURL string, remoteBackendTimeout time.Duration) (backend.EdgeDeviceBackend, error) {
+	if remoteBackendURL == "" {
+		f.Logger.Infof("Using Kubernetes, CRD-based backend")
+		return f.createK8sBackend(), nil
+	}
+
+	f.Logger.Infof("Using remote, HTTP-based backend")
+	return f.createRemoteBackend(remoteBackendURL, remoteBackendTimeout)
+}
+
+func (f *Factory) createRemoteBackend(remoteBackendURL string, remoteBackendTimeout time.Duration) (backend.EdgeDeviceBackend, error) {
+	backendURL, err := url.Parse(remoteBackendURL)
+	if err != nil {
+		return nil, err
+	}
+	var roundTripper http.RoundTripper
+	if backendURL.Scheme == "https" {
+		roundTripper = &http.Transport{
+			TLSClientConfig: f.TLSConfig,
+		}
+	}
+	config := backendclient.Config{
+		URL:       backendURL,
+		Transport: roundTripper,
+	}
+	backendApi := backendclient.New(config)
+	return remote.NewBackend(f.InitialDeviceNamespace, backendApi, remoteBackendTimeout, f.Logger), nil
+}
+
+func (f *Factory) createK8sBackend() backend.EdgeDeviceBackend {
+	// For now just one implementation is supported
+	k8sClient := k8sclient.NewK8sClient(f.Client)
+
+	edgeDeviceSignedRequestRepository := edgedevicesignedrequest.NewEdgedeviceSignedRequestRepository(f.Client)
+	edgeDeviceRepository := edgedevice.NewEdgeDeviceRepository(f.Client)
+	edgeWorkloadRepository := edgeworkload.NewEdgeWorkloadRepository(f.Client)
+	edgeDeviceSetRepository := edgedeviceset.NewEdgeDeviceSetRepository(f.Client)
 	k8sRepository := k8s.NewRepository(edgeDeviceSignedRequestRepository, edgeDeviceRepository, edgeWorkloadRepository,
 		edgeDeviceSetRepository, k8sClient)
 
-	claimer := storage.NewClaimer(client)
-	registryAuth := images.NewRegistryAuth(client)
+	claimer := storage.NewClaimer(f.Client)
+	registryAuth := images.NewRegistryAuth(f.Client)
 
 	assembler := k8s.NewConfigurationAssembler(
 		devicemetrics.NewAllowListGenerator(k8sClient),
 		claimer,
 		configmaps.NewConfigMap(k8sClient),
-		eventRecorder,
+		f.EventRecorder,
 		registryAuth,
 		k8sRepository,
 	)
-	return k8s.NewBackend(k8sRepository, assembler, logger, initialDeviceNamespace, eventRecorder)
+	return k8s.NewBackend(k8sRepository, assembler, f.Logger, f.InitialDeviceNamespace, f.EventRecorder)
 }

--- a/internal/edgeapi/backend/factory/factory_test.go
+++ b/internal/edgeapi/backend/factory/factory_test.go
@@ -1,27 +1,67 @@
 package factory_test
 
 import (
+	"crypto/tls"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/project-flotta/flotta-operator/internal/edgeapi/backend/factory"
 )
 
 const namespace = "some-ns"
 
+var logger, _ = zap.NewDevelopment()
+
 var _ = Describe("Backend factory", func() {
 
-	It("should create k8s factory", func() {
+	It("should create k8s backend", func() {
 		// given
-		logger := &zap.SugaredLogger{}
-		eventRecorder := record.NewFakeRecorder(1)
-		var c client.Client
+		factory := factory.Factory{
+			InitialDeviceNamespace: namespace,
+			Logger:                 logger.Sugar(),
+			Client:                 nil,
+			EventRecorder:          record.NewFakeRecorder(1),
+		}
 
 		// when
-		backend := factory.Create(namespace, c, logger, eventRecorder)
+		backend, _ := factory.Create("", time.Second)
+
+		// then
+		Expect(backend).ToNot(BeNil())
+	})
+
+	It("should create remote HTTP backend", func() {
+		// given
+		factory := factory.Factory{
+			InitialDeviceNamespace: namespace,
+			Logger:                 logger.Sugar(),
+			Client:                 nil,
+			EventRecorder:          record.NewFakeRecorder(1),
+		}
+
+		// when
+		backend, _ := factory.Create("http://project-flotta.com", time.Second)
+
+		// then
+		Expect(backend).ToNot(BeNil())
+	})
+
+	It("should create remote HTTPS backend", func() {
+		// given
+		factory := factory.Factory{
+			InitialDeviceNamespace: namespace,
+			Logger:                 logger.Sugar(),
+			Client:                 nil,
+			EventRecorder:          record.NewFakeRecorder(1),
+			TLSConfig:              &tls.Config{},
+		}
+
+		// when
+		backend, _ := factory.Create("https://project-flotta.com", time.Second)
 
 		// then
 		Expect(backend).ToNot(BeNil())

--- a/internal/edgeapi/config.go
+++ b/internal/edgeapi/config.go
@@ -1,0 +1,38 @@
+package edgeapi
+
+import "time"
+
+type Config struct {
+
+	// The port of the HTTPs server
+	HttpsPort uint16 `envconfig:"HTTPS_PORT" default:"8043"`
+
+	// Domain where TLS certificate listen.
+	// FIXME check default here
+	Domain string `envconfig:"DOMAIN" default:"project-flotta.io"`
+
+	// If TLS server certificates should work on 127.0.0.1
+	TLSLocalhostEnabled bool `envconfig:"TLS_LOCALHOST_ENABLED" default:"true"`
+
+	// The address the metric endpoint binds to.
+	MetricsAddr string `envconfig:"METRICS_ADDR" default:":8080"`
+
+	// Verbosity of the logger.
+	LogLevel string `envconfig:"LOG_LEVEL" default:"info"`
+
+	// Client Certificate expiration time
+	ClientCertExpirationTime uint `envconfig:"CLIENT_CERT_EXPIRATION_DAYS" default:"30"`
+
+	// Kubeconfig specifies path to a kubeconfig file if the server is run outside of a cluster
+	Kubeconfig string `envconfig:"KUBECONFIG" default:""`
+
+	// Backend specifies which backend storage should be used. Allowed values: "crd" and "remote".
+	Backend string `envconfig:"BACKEND" default:"crd"`
+
+	// RemoteBackendURL contains URL to a remote data store that should be used instead of the default CRD-based one.
+	// For HTTPS mTLS connections server cert and CA will be used.
+	RemoteBackendURL string `envconfig:"REMOTE_BACKEND_URL" default:""`
+
+	// RemoteBackendTimeout specifies timeout. Has to be parsable to time.Duration
+	RemoteBackendTimeout time.Duration `envconfig:"REMOT_BACKEND_TIMEOUT" default:"5s"`
+}


### PR DESCRIPTION
This PR adds support for choosing remote HTTP backend in the Edge API server instead of default k8s-based one.

To use remote backend, following env property needs to be set for the Edge API server: `REMOTE_BACKEND_URL`. If URL uses `https` schema, Edge API Server's TLS certificates will be used (same as ones used for handling agent connections).

Signed-off-by: Jakub Dzon <jdzon@redhat.com>