### PR TITLE
Added EdgeDevice finalizer to ensure EDSR removal

### DIFF
--- a/controllers/edgedevice_controller.go
+++ b/controllers/edgedevice_controller.go
@@ -34,6 +34,11 @@ import (
 	"github.com/project-flotta/flotta-operator/internal/common/repository/edgedevice"
 	"github.com/project-flotta/flotta-operator/internal/common/repository/edgedevicesignedrequest"
 	"github.com/project-flotta/flotta-operator/internal/common/storage"
+	"github.com/project-flotta/flotta-operator/internal/common/utils"
+)
+
+const (
+	DeviceFinalizer = "device-finalizer"
 )
 
 // EdgeDeviceReconciler reconciles a EdgeDevice object
@@ -80,15 +85,10 @@ func (r *EdgeDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if edgeDevice.DeletionTimestamp != nil {
-		edsr, err := r.EdgeDeviceSignedRequestRepository.Read(ctx, edgeDevice.Name, r.InitialDeviceNamespace)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return ctrl.Result{}, nil
-			}
+		if err := r.removeRelatedEDSR(ctx, edgeDevice); err != nil {
 			return ctrl.Result{Requeue: true}, err
 		}
-		err = r.EdgeDeviceSignedRequestRepository.Delete(ctx, edsr)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, r.removeFinalizer(ctx, edgeDevice)
 	}
 
 	if !r.ObcAutoCreate && !storage.ShouldCreateOBC(edgeDevice.Spec.Storage) {
@@ -108,6 +108,27 @@ func (r *EdgeDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 	return ctrl.Result{}, nil
+}
+
+func (r *EdgeDeviceReconciler) removeRelatedEDSR(ctx context.Context, edgeDevice *mgmtv1alpha1.EdgeDevice) error {
+	edsr, err := r.EdgeDeviceSignedRequestRepository.Read(ctx, edgeDevice.Name, r.InitialDeviceNamespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return r.EdgeDeviceSignedRequestRepository.Delete(ctx, edsr)
+}
+
+func (r *EdgeDeviceReconciler) removeFinalizer(ctx context.Context, edgeDevice *mgmtv1alpha1.EdgeDevice) error {
+	if utils.HasFinalizer(&edgeDevice.ObjectMeta, DeviceFinalizer) {
+		if err := r.EdgeDeviceRepository.RemoveFinalizer(ctx, edgeDevice, DeviceFinalizer); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *EdgeDeviceReconciler) createOrGetObc(ctx context.Context, edgeDevice *mgmtv1alpha1.EdgeDevice) (*obv1.ObjectBucketClaim, error) {

--- a/controllers/edgedevicesignedrequest_controller.go
+++ b/controllers/edgedevicesignedrequest_controller.go
@@ -87,6 +87,9 @@ func (r *EdgeDeviceSignedRequestReconciler) Reconcile(ctx context.Context, req c
 			Labels: map[string]string{
 				v1alpha1.EdgeDeviceSignedRequestLabelName: v1alpha1.EdgeDeviceSignedRequestLabelValue,
 			},
+			Finalizers: []string{
+				DeviceFinalizer,
+			},
 		},
 		Spec: managementv1alpha1.EdgeDeviceSpec{
 			RequestTime: &now,

--- a/internal/common/repository/edgedevice/mock_edgedevice.go
+++ b/internal/common/repository/edgedevice/mock_edgedevice.go
@@ -125,6 +125,20 @@ func (mr *MockRepositoryMockRecorder) Read(arg0, arg1, arg2 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRepository)(nil).Read), arg0, arg1, arg2)
 }
 
+// RemoveFinalizer mocks base method.
+func (m *MockRepository) RemoveFinalizer(arg0 context.Context, arg1 *v1alpha1.EdgeDevice, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveFinalizer", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveFinalizer indicates an expected call of RemoveFinalizer.
+func (mr *MockRepositoryMockRecorder) RemoveFinalizer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFinalizer", reflect.TypeOf((*MockRepository)(nil).RemoveFinalizer), arg0, arg1, arg2)
+}
+
 // UpdateLabels mocks base method.
 func (m *MockRepository) UpdateLabels(arg0 context.Context, arg1 *v1alpha1.EdgeDevice, arg2 map[string]string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR introduces a new `EdgeDevice` finalier to ensure that related `EDSR` is removed. 
This finalizer _does not_ directly block device deregistration.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>