### PR TITLE
Replacing reconcile-based EDSR clean-up with owner reference

### DIFF
--- a/controllers/edgedevice_controller.go
+++ b/controllers/edgedevice_controller.go
@@ -79,18 +79,6 @@ func (r *EdgeDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	if edgeDevice.DeletionTimestamp != nil {
-		edsr, err := r.EdgeDeviceSignedRequestRepository.Read(ctx, edgeDevice.Name, r.InitialDeviceNamespace)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return ctrl.Result{}, nil
-			}
-			return ctrl.Result{Requeue: true}, err
-		}
-		err = r.EdgeDeviceSignedRequestRepository.Delete(ctx, edsr)
-		return ctrl.Result{}, err
-	}
-
 	if !r.ObcAutoCreate && !storage.ShouldCreateOBC(edgeDevice.Spec.Storage) {
 		return ctrl.Result{}, nil
 	}

--- a/controllers/edgedevicesignedrequest_controller.go
+++ b/controllers/edgedevicesignedrequest_controller.go
@@ -87,9 +87,6 @@ func (r *EdgeDeviceSignedRequestReconciler) Reconcile(ctx context.Context, req c
 			Labels: map[string]string{
 				v1alpha1.EdgeDeviceSignedRequestLabelName: v1alpha1.EdgeDeviceSignedRequestLabelValue,
 			},
-			Finalizers: []string{
-				DeviceFinalizer,
-			},
 		},
 		Spec: managementv1alpha1.EdgeDeviceSpec{
 			RequestTime: &now,

--- a/internal/common/repository/edgedevice/edgedevice.go
+++ b/internal/common/repository/edgedevice/edgedevice.go
@@ -20,7 +20,6 @@ type Repository interface {
 	Patch(ctx context.Context, old, new *v1alpha1.EdgeDevice) error
 	ListForSelector(ctx context.Context, selector *metav1.LabelSelector, namespace string) ([]v1alpha1.EdgeDevice, error)
 	ListForWorkload(ctx context.Context, name string, namespace string) ([]v1alpha1.EdgeDevice, error)
-	RemoveFinalizer(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice, finalizer string) error
 	UpdateLabels(ctx context.Context, device *v1alpha1.EdgeDevice, labels map[string]string) error
 }
 
@@ -77,25 +76,6 @@ func (r CRRepository) ListForWorkload(ctx context.Context, name string, namespac
 	}
 
 	return edl.Items, nil
-}
-
-func (r *CRRepository) RemoveFinalizer(ctx context.Context, edgeDevice *v1alpha1.EdgeDevice, finalizer string) error {
-	cp := edgeDevice.DeepCopy()
-
-	var finalizers []string
-	for _, f := range cp.Finalizers {
-		if f != finalizer {
-			finalizers = append(finalizers, f)
-		}
-	}
-	cp.Finalizers = finalizers
-
-	err := r.Patch(ctx, edgeDevice, cp)
-	if err == nil {
-		edgeDevice.Finalizers = cp.Finalizers
-	}
-
-	return nil
 }
 
 func (r *CRRepository) UpdateLabels(ctx context.Context, device *v1alpha1.EdgeDevice, labels map[string]string) error {

--- a/internal/common/repository/edgedevice/mock_edgedevice.go
+++ b/internal/common/repository/edgedevice/mock_edgedevice.go
@@ -125,20 +125,6 @@ func (mr *MockRepositoryMockRecorder) Read(arg0, arg1, arg2 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRepository)(nil).Read), arg0, arg1, arg2)
 }
 
-// RemoveFinalizer mocks base method.
-func (m *MockRepository) RemoveFinalizer(arg0 context.Context, arg1 *v1alpha1.EdgeDevice, arg2 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveFinalizer", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveFinalizer indicates an expected call of RemoveFinalizer.
-func (mr *MockRepositoryMockRecorder) RemoveFinalizer(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFinalizer", reflect.TypeOf((*MockRepository)(nil).RemoveFinalizer), arg0, arg1, arg2)
-}
-
 // UpdateLabels mocks base method.
 func (m *MockRepository) UpdateLabels(arg0 context.Context, arg1 *v1alpha1.EdgeDevice, arg2 map[string]string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR reverts #252 and replaces reconcile-based `EDSR` clean-up on `EdgeDevice` removal.