### PR TITLE
Fix wrong workload status on device after deletion

### DIFF
--- a/internal/common/indexer/indexer.go
+++ b/internal/common/indexer/indexer.go
@@ -19,7 +19,7 @@ const (
 
 func WorkloadByDeviceIndexFunc(obj ctrlruntimeclient.Object) []string {
 	workload, ok := obj.(*v1alpha1.EdgeWorkload)
-	if !ok {
+	if !ok || workload.DeletionTimestamp != nil {
 		return []string{}
 	}
 	var keys []string

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -104,6 +104,26 @@ var _ = Describe("e2e", func() {
 			Expect(err).To(BeNil())
 			Expect(stdout).To(ContainSubstring("Welcome to nginx!"))
 		})
+		It("Deploy then remove valid edgeworkload to registered device", func() {
+			// given
+			err := device.Register()
+			Expect(err).To(BeNil())
+
+			// when
+			w, err := workload.Create(edgeworkloadDeviceId("nginx", device.GetId(), hostPort, nginxPort))
+			Expect(err).To(BeNil())
+
+			// then
+			// Check the edgedevice report proper state of workload:
+			err = device.WaitForWorkloadState("nginx", "Running")
+			Expect(err).To(BeNil(), "cannot get workload status for nginx workload")
+			// Check there is no Workload attached to the device after the workload is deleted
+			err = workload.Remove(w.Name)
+			Expect(err).To(BeNil())
+			e, err := device.Get()
+			Expect(err).To(BeNil())
+			Expect(len(e.Status.Workloads)).To(Equal(0))
+		})
 
 		It("Deploy valid edgeworkload to registered device where pod and container name is different", func() {
 			// given


### PR DESCRIPTION
Fix the wrong status  of a workload after its deletion: the workload should not be in edgedevice resource after it has been deleted

Current:
```
name: workload
phase: Deploying
```

After fix:
`null`

Signed-off-by: Gabriel Farache gfarache@redhat.com