### PR TITLE
Fix: Configure ReadHeaderTimeout in cmd/httpapi/main.go

### DIFF
--- a/cmd/httpapi/main.go
+++ b/cmd/httpapi/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	obv1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
@@ -170,9 +171,10 @@ func main() {
 	}
 
 	server := &http.Server{
-		Addr:      fmt.Sprintf(":%v", Config.HttpsPort),
-		TLSConfig: tlsConfig,
-		Handler:   handler,
+		Addr:              fmt.Sprintf(":%v", Config.HttpsPort),
+		TLSConfig:         tlsConfig,
+		Handler:           handler,
+		ReadHeaderTimeout: 32 * time.Second,
 	}
 	go func() {
 		logger.Fatal(server.ListenAndServeTLS("", ""))


### PR DESCRIPTION
# Description
The `SecurityScanner` job is failing with the following reason:
```
[/github/workspace/cmd/httpapi/main.go:172-176] - G112 (CWE-400): Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (Confidence: LOW, Severity: MEDIUM)
    171:
  > 172: 	server := &http.Server{
  > 173: 		Addr:      fmt.Sprintf(":%v", Config.HttpsPort),
  > 174: 		TLSConfig: tlsConfig,
  > 175: 		Handler:   handler,
  > 176: 	}
    177: 	go func() {
```
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Signed-off-by: Gloria Ciavarrini <gciavarrini@redhat.com>