### PR TITLE
Harmonize logging with SugaredLogger to avoid wrong formatting

### DIFF
--- a/cmd/httpapi/main.go
+++ b/cmd/httpapi/main.go
@@ -156,7 +156,7 @@ func main() {
 				authType := yggdrasilAPIHandler.GetAuthType(r, api)
 				if ok, err := mtls.VerifyRequest(r, authType, opts, CACertChain, yggdrasil.AuthzKey, logger); !ok {
 					metricsObj.IncEdgeDeviceFailedAuthenticationCounter()
-					logger.Info("cannot verify request:", "authType", authType, "method", r.Method, "url", r.URL, "err", err)
+					logger.With("authType", authType, "method", r.Method, "url", r.URL, "err", err).Info("cannot verify request")
 					w.WriteHeader(http.StatusUnauthorized)
 					return
 				}

--- a/internal/edgeapi/backend/k8s/backend.go
+++ b/internal/edgeapi/backend/k8s/backend.go
@@ -136,7 +136,7 @@ func (b *backend) GetTargetNamespace(ctx context.Context, name, identityNamespac
 	// the first time that tries to register should be able to use register certificate.
 	if !isInit && !matchesCertificate {
 		authKeyVal, _ := ctx.Value(AuthzKey).(mtls.RequestAuthVal)
-		logger.Debug("Device tries to re-register with an invalid certificate", "certcn", authKeyVal.CommonName)
+		logger.With("certcn", authKeyVal.CommonName).Debug("Device tries to re-register with an invalid certificate")
 		// At this moment, the registration certificate it's no longer valid,
 		// because the CR is already created, and need to be a device
 		// certificate.
@@ -162,7 +162,7 @@ func (b *backend) Register(ctx context.Context, name, namespace string, registra
 
 	err = b.repository.PatchEdgeDevice(ctx, dvc, deviceCopy)
 	if err != nil {
-		logger.Error(err, "cannot update edgedevice")
+		logger.With("err", err).Error("cannot update edgedevice")
 		return err
 	}
 

--- a/internal/edgeapi/backend/k8s/heartbeat-handler.go
+++ b/internal/edgeapi/backend/k8s/heartbeat-handler.go
@@ -33,7 +33,7 @@ func (h *SynchronousHandler) Process(ctx context.Context, name, namespace string
 	logger := h.logger.With("DeviceID", name, "Namespace", namespace)
 
 	retry := ctx.Value(backendapi.RetryContextKey)
-	logger.Debug("processing heartbeat", "content", heartbeat, "retry", retry)
+	logger.With("content", heartbeat, "retry", retry).Debug("processing heartbeat")
 	edgeDevice, err := h.repository.GetEdgeDevice(ctx, name, namespace)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/internal/edgeapi/yggdrasil/yggdrasil.go
+++ b/internal/edgeapi/yggdrasil/yggdrasil.go
@@ -112,7 +112,7 @@ func (h *Handler) GetControlMessageForDevice(ctx context.Context, params yggdras
 			logger.Info("edge device is not found")
 			return operations.NewGetControlMessageForDeviceNotFound()
 		}
-		logger.Error(err, "failed to get edge device")
+		logger.With("err", err).Error("failed to get edge device")
 		return operations.NewGetControlMessageForDeviceInternalServerError()
 	}
 
@@ -139,7 +139,7 @@ func (h *Handler) GetDataMessageForDevice(ctx context.Context, params yggdrasil.
 			logger.Info("edge device is not found")
 			return operations.NewGetDataMessageForDeviceNotFound()
 		}
-		logger.Error(err, "failed to get edge device configuration")
+		logger.With("err", err).Error("failed to get edge device configuration")
 		return operations.NewGetDataMessageForDeviceInternalServerError()
 	}
 
@@ -191,7 +191,7 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 				logger.Debug("Device not found")
 				return operations.NewPostDataMessageForDeviceNotFound()
 			}
-			logger.Error(err, "Device not found")
+			logger.With("err", err).Error("Device not found")
 			return operations.NewPostDataMessageForDeviceInternalServerError()
 		}
 		h.metrics.RecordEdgeDevicePresence(h.getNamespace(ctx), deviceID)
@@ -202,7 +202,7 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 		if err != nil {
 			return operations.NewPostDataMessageForDeviceBadRequest()
 		}
-		logger.Debug("received enrolment info", "content", enrolmentInfo)
+		logger.With("content", enrolmentInfo).Debug("received enrolment info")
 		targetNamespace := h.initialNamespace
 		if enrolmentInfo.TargetNamespace != nil {
 			targetNamespace = *enrolmentInfo.TargetNamespace
@@ -225,7 +225,7 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 		if err != nil {
 			return operations.NewPostDataMessageForDeviceBadRequest()
 		}
-		logger.Debug("received registration info", "content", registrationInfo)
+		logger.With("content", registrationInfo).Debug("received registration info")
 		res := models.MessageResponse{
 			Directive: msg.Directive,
 			MessageID: msg.MessageID,
@@ -235,7 +235,7 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 
 		ns, err = h.backend.GetTargetNamespace(ctx, deviceID, ns, IsOwnDevice(ctx, deviceID))
 		if err != nil {
-			logger.Error(err, "can't get target namespace for a device")
+			logger.With("err", err).Error("can't get target namespace for a device")
 			if !errors.IsNotFound(err) {
 				h.metrics.IncEdgeDeviceFailedRegistration()
 				return operations.NewPostDataMessageForDeviceInternalServerError()
@@ -256,7 +256,7 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 		err = h.backend.Register(ctx, deviceID, ns, &registrationInfo)
 
 		if err != nil {
-			logger.Error(err, "cannot finalize device registration")
+			logger.With("err", err).Error("cannot finalize device registration")
 			h.metrics.IncEdgeDeviceFailedRegistration()
 			return operations.NewPostDataMessageForDeviceInternalServerError()
 		}
@@ -264,7 +264,7 @@ func (h *Handler) PostDataMessageForDevice(ctx context.Context, params yggdrasil
 		h.metrics.IncEdgeDeviceSuccessfulRegistration()
 		return operations.NewPostDataMessageForDeviceOK().WithPayload(&res)
 	default:
-		logger.Info("received unknown message", "message", msg)
+		logger.With("message", msg).Info("received unknown message")
 		return operations.NewPostDataMessageForDeviceBadRequest()
 	}
 	return operations.NewPostDataMessageForDeviceOK()

--- a/pkg/mtls/ca.go
+++ b/pkg/mtls/ca.go
@@ -237,7 +237,7 @@ func VerifyRequest(r *http.Request, verifyType int, verifyOpts x509.VerifyOption
 		}
 
 		if _, err := cert.Verify(verifyOpts); err != nil {
-			logger.Error("Failed to verify client cert: %v", err)
+			logger.Errorf("Failed to verify client cert: %v", err)
 			return false, &ClientCertificateVerifyError{err}
 		}
 	}


### PR DESCRIPTION
Fix the wrong formatting when using SugaredLogger

Current:
```
2022-06-08T12:51:50.150+0300    INFO    httpapi/main.go:158     cannot verify request:authType0methodGETurl/api/flotta-management/v1/control/07b68c4e41b04cb987ef171766c01147/inerrcannot use register certificate on this resource 
2022-06-08T12:51:50.150+0300    INFO    httpapi/main.go:158     cannot verify request:authType0methodGETurl/api/flotta-management/v1/data/07b68c4e41b04cb987ef171766c01147/inerrcannot use register certificate on this resource 
       2022-06-08T12:51:55.155+0300    INFO    httpapi/main.go:158     cannot verify request:authType0methodGETurl/api/flotta-management/v1/control/07b68c4e41b04cb987ef171766c01147/inerrcannot use register certificate on this resource 
2022-06-08T12:51:55.156+0300    INFO    httpapi/main.go:158     cannot verify request:authType0methodGETurl/api/flotta-management/v1/data/07b68c4e41b04cb987ef171766c01147/inerrcannot use register certificate on this resource 
2022-06-08T12:51:55.411+0300    ERROR   yggdrasil/yggdrasil.go:238      forbiddencan't get target namespace for a device        {"DeviceID": "07b68c4e41b04cb987ef171766c01147"}
```
After fix:
```
2022-06-15T14:39:36.833Z        INFO    workspace/main.go:158   cannot verify request   {"authType": 0, "method": "GET", "url": "/api/flotta-management/v1/control/3251c266033744c088c4e4db3074f7fa/in", "err": "cannot use register certificate on this resource"}
2022-06-15T14:39:41.838Z        INFO    workspace/main.go:158   cannot verify request   {"authType": 0, "method": "GET", "url": "/api/flotta-management/v1/control/3251c266033744c088c4e4db3074f7fa/in", "err": "cannot use register certificate on this resource"}
2022-06-15T14:39:41.838Z        INFO    workspace/main.go:158   cannot verify request   {"authType": 0, "method": "GET", "url": "/api/flotta-management/v1/data/3251c266033744c088c4e4db3074f7fa/in", "err": "cannot use register certificate on this resource"}
2022-06-15T14:39:46.840Z        INFO    workspace/main.go:158   cannot verify request   {"authType": 0, "method": "GET", "url": "/api/flotta-management/v1/data/3251c266033744c088c4e4db3074f7fa/in", "err": "cannot use register certificate on this resource"}
2022-06-15T14:39:46.840Z        INFO    workspace/main.go:158   cannot verify request   {"authType": 0, "method": "GET", "url": "/api/flotta-management/v1/control/3251c266033744c088c4e4db3074f7fa/in", "err": "cannot use register certificate on this resource"}
```

Signed-off-by: Gabriel Farache [gfarache@redhat.com](mailto:gfarache@redhat.com)