### PR TITLE
Fix gosec

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -77,5 +77,7 @@ jobs:
 
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
+        env:
+          GOFLAGS: -buildvcs=false
         with:
-          args: '-exclude-generated  ./...'
+          args: '-exclude-generated ./...'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -78,4 +78,4 @@ jobs:
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:
-          args: '-no-fail -exclude-generated  ./...'
+          args: '-exclude-generated  ./...'


### PR DESCRIPTION
Fixes the gosec issue with VCS in go 1.18 and reverts the previous patch to ignore this failure:

```bash

Golang errors in file: []:
  > [line 0 : column 0] - error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```
