### PR TITLE
CI: Fix e2e flakes

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -29,6 +29,7 @@ jobs:
         run: |
           sudo rm /etc/docker/daemon.json
           sudo systemctl restart docker
+          docker system info
 
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
@@ -49,7 +50,7 @@ jobs:
 
           unzip my -d /var/tmp/flotta
 
-      - name: Testing on KinD
+      - name: Prepare KinD
         run: |
           # Print cluster info
           kubectl cluster-info
@@ -70,6 +71,8 @@ jobs:
           fi
           kubectl wait --timeout=120s --for=condition=Ready pods --all -n flotta
 
+      - name: Testing on KinD
+        run: |
           # Run test
           INPUT_IMAGE="${{ github.event.inputs.image }}"
           if [ -n "${{ github.event.inputs.artifact_url }}" ]; then

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -70,7 +70,7 @@ var _ = Describe("e2e", func() {
 			Expect(stdout).To(Equal("active"))
 
 			// Check the podman.socket is running:
-			stdout, err = device.Exec("systemctl --machine flotta@.host is-active --user podman.socket")
+			stdout, err = device.Exec("sudo -u flotta systemctl is-active --user podman.socket")
 			Expect(err).To(BeNil())
 			Expect(stdout).To(Equal("active"))
 
@@ -206,9 +206,9 @@ var _ = Describe("e2e", func() {
 			}).WithTimeout(180 * time.Second).Should(Equal("0"))
 
 			// no pods running
-			stdout, err := device.Exec("machinectl shell -q flotta@.host /usr/bin/podman ps --noheading | wc -l")
+			stdout, err := device.Exec("sudo -u flotta /usr/bin/podman ps --noheading | wc -l")
 			Expect(err).To(BeNil())
-			Expect(stdout).To(Equal("1")) // machinectl print one empty new line
+			Expect(stdout).To(Equal("0"))
 
 			// EdgeWorkload CR still exists
 			depCr, err := workload.Get("nginx")
@@ -251,7 +251,7 @@ var _ = Describe("e2e", func() {
 			Expect(err).To(BeNil())
 
 			// then
-			stdout, err := device.Exec("systemctl --machine flotta@.host is-failed --user pod-nginx_pod.service")
+			stdout, err := device.Exec("sudo -u flotta systemctl is-failed --user pod-nginx_pod.service")
 			Expect(err).To(BeNil())
 			Expect(stdout).To(BeElementOf([]string{"activating", "deactivating", "inactive"}))
 		})
@@ -307,7 +307,7 @@ var _ = Describe("e2e", func() {
 			Expect(err).To(BeNil())
 
 			// then
-			stdout, err := device.Exec("machinectl shell -q flotta@.host /usr/bin/podman exec nginx_pod-nginx env | grep key1")
+			stdout, err := device.Exec("sudo -u flotta /usr/bin/podman exec nginx_pod-nginx env | grep key1")
 			Expect(err).To(BeNil())
 			Expect(stdout).To(Equal("key1=config1"))
 
@@ -341,7 +341,7 @@ var _ = Describe("e2e", func() {
 			Expect(err).To(BeNil())
 
 			// then
-			stdout, err := device.Exec("machinectl shell -q flotta@.host /usr/bin/podman exec nginx_pod-nginx env | grep key1")
+			stdout, err := device.Exec("sudo -u flotta /usr/bin/podman exec nginx_pod-nginx env | grep key1")
 			Expect(err).To(BeNil())
 			Expect(stdout).To(Equal("key1=config1"))
 


### PR DESCRIPTION
With the new changes on RPM/systemd/sysusers the e2e was failing hard.
This commit adds the following changes:

- Avoid the use of machine-ctl and use sudo -u flotta
- Forcing endpoint container to have CgroupNsMode to private.
- Separate kind phases to make it easier to debug failures.
- Gatter better logs
