### PR TITLE
Install: Fix rpm-ostree service

### DIFF
--- a/hack/install-agent-rpm-ostree.sh.template
+++ b/hack/install-agent-rpm-ostree.sh.template
@@ -89,6 +89,7 @@ cat <<EOF >/etc/systemd/system/init-yggd.service
 [Unit]
 Description=Initialize yggdrasild configuration.
 Before=yggdrasild.service
+After=flotta-agent.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
When starting init-yggd service, need to run *after* the flotta-agent,
the service that creates the user.

This is needed because flotta user id need to be part of the
device-worker env variables.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>