### PR TITLE
CI: Fix some invalid typos

### DIFF
--- a/test/e2e/edgedevice_test.go
+++ b/test/e2e/edgedevice_test.go
@@ -102,8 +102,7 @@ func (e *edgeDeviceDocker) WaitForWorkloadState(workloadName string, workloadPha
 				return true
 			}
 		}
-		ginkgo.GinkgoT().Logf("WaitForWorkloadState failed since workloadName didn't match any workload\n")
-		ginkgo.GinkgoT().Logf("Device Status :%+v", device.Status)
+		ginkgo.GinkgoT().Logf("WaitForWorkloadState failed since workloadName didn't match any workload, status: %v\n", device.Status)
 		return false
 	})
 }
@@ -165,9 +164,7 @@ func (e *edgeDeviceDocker) GetLogs(extraCommands ...string) (map[string]string, 
 		"ps aux",
 		"sudo -u flotta systemctl status --full --no-pager --user podman",
 		"sudo -u flotta /usr/bin/podman ps -a",
-		"sudo -u flotta /usr/bin/podman pod ps -a",
-		"ls /etc/yggdrasil/device/volumes/ -lah",
-		"ls /etc/yggdrasil/device/ -lah",
+		"sudo -u flotta /usr/bin/podman pod ps",
 		"systemctl status yggdrasild",
 		"sudo -u flotta systemctl status --user",
 	}


### PR DESCRIPTION
PR #275 was a test PR to debug why the 2e2 testing CI job was failing
because I was unable to replicate it. That PR had a cherry-pick of PR #267,
and some other code to help to understand why it didn't work.

With this change, some typos are deleted and also some invalid commands
made for debugging.

And yes, the commits on that PR were super bad, I know, I didn't expect
that got merged in any way, sorry!

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>