### PR TITLE
Propagate edgeworkload annotations

### DIFF
--- a/internal/common/labels/labels.go
+++ b/internal/common/labels/labels.go
@@ -26,14 +26,3 @@ func IsSelectorLabel(label string) bool {
 func CreateSelectorLabel(label string) string {
 	return SelectorLabelPrefix + label
 }
-
-// GetPodmanLabels filter all the labels of the EdgeWorkload CR starting with prefix "podman/"
-func GetPodmanLabels(workloadLabels map[string]string) map[string]string {
-	labels := map[string]string{}
-	for key, value := range workloadLabels {
-		if strings.HasPrefix(key, "podman/") {
-			labels[key[7:]] = value
-		}
-	}
-	return labels
-}

--- a/internal/common/utils/utils.go
+++ b/internal/common/utils/utils.go
@@ -122,3 +122,17 @@ func ExtractInfoFromEnv(env []corev1.EnvVar, configmapMap MapType, ref GetRefEnv
 		}
 	}
 }
+
+// FilterByPodmanPrefix does two things:
+// first it filters the keys that start with prefix "podman/"
+// And secondly, of those keys that have the "podman/" prefix, it uses the remaining part of the key as the new key in the returning map with the same value as in the original map
+// e.g. 'podman/this-is-my-key:1' is stored in the returning map as 'this-is-my-key:1'
+func FilterByPodmanPrefix(keyValues map[string]string) map[string]string {
+	ret := map[string]string{}
+	for key, value := range keyValues {
+		if strings.HasPrefix(key, "podman/") {
+			ret[key[7:]] = value
+		}
+	}
+	return ret
+}

--- a/internal/common/utils/utils_test.go
+++ b/internal/common/utils/utils_test.go
@@ -266,4 +266,31 @@ var _ = Describe("Utils", func() {
 			Expect(ok).To(BeTrue())
 		})
 	})
+	Context("FilterByPodmanPrefix", func() {
+		It("should return empty with an empty map", func() {
+			// given
+			aMap := map[string]string{}
+			// when
+			ret := utils.FilterByPodmanPrefix(aMap)
+			// then
+			Expect(ret).To(BeEmpty())
+
+		})
+		It("should return no keys when none match the 'podman/' prefix", func() {
+			// given
+			aMap := map[string]string{"noMatch": "1", "podman-/this-key": "1"}
+			// when
+			ret := utils.FilterByPodmanPrefix(aMap)
+			// then
+			Expect(ret).To(BeEmpty())
+		})
+		It("should return a key value pair with the 'podman/' removed when a match is found", func() {
+			// given
+			aMap := map[string]string{"noMatch": "1", "podman/pod_label": "1"}
+			// when
+			ret := utils.FilterByPodmanPrefix(aMap)
+			// then
+			Expect(ret).To(BeEquivalentTo(map[string]string{"pod_label": "1"}))
+		})
+	})
 })

--- a/internal/edgeapi/backend/k8s/configuration-assembler.go
+++ b/internal/edgeapi/backend/k8s/configuration-assembler.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/project-flotta/flotta-operator/api/v1alpha1"
-	"github.com/project-flotta/flotta-operator/internal/common/labels"
 	"github.com/project-flotta/flotta-operator/internal/common/storage"
+	"github.com/project-flotta/flotta-operator/internal/common/utils"
 	"github.com/project-flotta/flotta-operator/internal/edgeapi/configmaps"
 	"github.com/project-flotta/flotta-operator/internal/edgeapi/devicemetrics"
 	"github.com/project-flotta/flotta-operator/internal/edgeapi/images"
@@ -302,7 +302,8 @@ func (a *ConfigurationAssembler) toWorkloadList(ctx context.Context, logger *zap
 		workload := models.Workload{
 			Name:          edgeworkload.Name,
 			Namespace:     edgeworkload.Namespace,
-			Labels:        labels.GetPodmanLabels(edgeworkload.Labels),
+			Annotations:   utils.FilterByPodmanPrefix(edgeworkload.Annotations),
+			Labels:        utils.FilterByPodmanPrefix(edgeworkload.Labels),
 			Specification: string(podSpec),
 			Data:          data,
 			LogCollection: spec.LogCollection,

--- a/models/workload.go
+++ b/models/workload.go
@@ -18,6 +18,9 @@ import (
 // swagger:model workload
 type Workload struct {
 
+	// Workload Annotations
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// configmaps
 	Configmaps ConfigmapList `json:"configmaps,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1048,6 +1048,13 @@ func init() {
     "workload": {
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Workload Annotations",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "configmaps": {
           "$ref": "#/definitions/configmap-list"
         },
@@ -2185,6 +2192,13 @@ func init() {
     "workload": {
       "type": "object",
       "properties": {
+        "annotations": {
+          "description": "Workload Annotations",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "configmaps": {
           "$ref": "#/definitions/configmap-list"
         },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -344,6 +344,11 @@ definitions:
       log_collection:
         description: Log collection target for this workload
         type: string
+      annotations:
+        type: object
+        description: Workload Annotations
+        additionalProperties:
+          type: string
   secret-list:
     description: List of secrets used by the workloads
     type: array


### PR DESCRIPTION
Adds the possibility to propagate `annotations` in the edgeworkload to the pod manifest. This feature is needed to enable the use of `crun` annotation  `run.oci.keep_original_groups: "1"` which instructs `crun` to keep the same group Ids in the host user to the container user, enabling the possibility of accessing host devices inside the container based on group affinity by the host user.