### PR TITLE
Remove podman services start

### DIFF
--- a/hack/install-agent-dnf.sh.template
+++ b/hack/install-agent-dnf.sh.template
@@ -92,7 +92,5 @@ EOF
 
 systemctl disable firewalld.service
 systemctl enable nftables.service
-systemctl enable podman.service
-systemctl enable podman.socket
 systemctl enable yggdrasild.service
 systemctl reboot


### PR DESCRIPTION
podman.socket will be enabled after the reboot for flotta, no need to start it explicitly.

Signed-off-by: Moti Asayag <masayag@redhat.com>
