### PR TITLE
Fix for E2E tests when providing custom RPM: volumes directory inside…

### DIFF
--- a/test/e2e/edgedevice_test.go
+++ b/test/e2e/edgedevice_test.go
@@ -261,7 +261,7 @@ func (e *edgeDeviceDocker) Register(cmds ...string) error {
 		if err != nil {
 			return err
 		}
-		if _, err = e.Exec(fmt.Sprintf("dnf remove -y flotta-agent-race && dnf install -y /var/tmp/%s", filepath.Base(name))); err != nil {
+		if _, err = e.Exec(fmt.Sprintf("dnf remove -y flotta-agent-race && dnf install -y /var/tmp/%s && systemctl restart flotta-agent", filepath.Base(name))); err != nil {
 			return fmt.Errorf("cannot install custom rpm '%s': %v", name, err)
 		}
 	} else {


### PR DESCRIPTION
Fixes a problem when running a custom RPM that does not seem to start the flotta-agent service after installing it and misses the additional command to change ownership of the `/etc/yggdrasil/device/volumes` directory to `flotta:flotta` and change rights to 0777.

Without custom RPM:
```
[root@919ef9d98acf yggdrasil]# rpm -q flotta-agent-race
flotta-agent-race-0.2.0-3.fc36.x86_64
```
Directory access rights and ownership are correct:
```
[root@919ef9d98acf yggdrasil]# ls -la /etc/yggdrasil/device/
total 24
drwxr-xr-x. 1 root   root   4096 Jul 26 18:29 .
drwxr-xr-x. 1 root   root   4096 Jul 26 18:35 ..
drwxrwxrwx. 1 flotta flotta 4096 Jul 26 18:29 volumes
```

With custom RPM:
```
[root@919ef9d98acf yggdrasil]# rpm -q flotta-agent
flotta-agent-0.2.0-3.fc36.x86_64
```
Directory and access rights are invalid:
```
[root@919ef9d98acf yggdrasil]# ls -la /etc/yggdrasil/device/
total 20
drwxr-xr-x. 3 root root 4096 Jul 29 01:53 .
drwxr-xr-x. 1 root root 4096 Jul 29 01:53 ..
drwxr-xr-x. 2 root root 4096 Jul 29 01:53 volumes
```
Restarting the service fixes it:
```
[root@919ef9d98acf yggdrasil]# systemctl restart flotta-agent && ls -la /etc/yggdrasil/device
total 20
drwxr-xr-x. 3 root   root   4096 Jul 29 01:53 .
drwxr-xr-x. 1 root   root   4096 Jul 29 01:53 ..
drwxrwxrwx. 2 flotta flotta 4096 Jul 29 01:53 volumes
```