### PR TITLE
Fix: `io/ioutil` has been deprecated since Go 1.16

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -296,7 +295,7 @@ func getOperatorNamespace() (operatorNamespace string, err error) {
 		return defaultOperatorNamespace, nil
 	}
 
-	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/edgedevice_test.go
+++ b/test/e2e/edgedevice_test.go
@@ -3,7 +3,7 @@ package e2e_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -145,7 +145,7 @@ func (e *edgeDeviceDocker) Exec(command string) (string, error) {
 	}
 	defer response.Close()
 
-	data, err := ioutil.ReadAll(response.Reader)
+	data, err := io.ReadAll(response.Reader)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
# Description

`io/ioutil` has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package `io` or package `os`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


Signed-off-by: Gloria Ciavarrini <gciavarrini@redhat.com>