### PR TITLE
CI: Trigger github actions daily

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -5,6 +5,8 @@ on:  # yamllint disable-line rule:truthy
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '* 8 * * *'
   workflow_dispatch:
     inputs:
       image:


### PR DESCRIPTION
Trigger kind job daily to make sure that is not failing due a change in
the k4e-device-worker

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>

