### PR TITLE
Block workloads with `HostPort` 9100

### DIFF
--- a/api/v1alpha1/edgeworkload_webhook.go
+++ b/api/v1alpha1/edgeworkload_webhook.go
@@ -101,6 +101,14 @@ func (r *EdgeWorkload) validate() error {
 		} else {
 			containersNames[container.Name] = struct{}{}
 		}
+
+		if container.Ports != nil {
+			for _, port := range container.Ports {
+				if port.HostPort == 9100 {
+					return fmt.Errorf("HostPort 9100 is reserved for internal use on the device and cannot be set for user workloads")
+				}
+			}
+		}
 	}
 
 	for _, volume := range podSpec.Volumes {

--- a/api/v1alpha1/edgeworkload_webhook_test.go
+++ b/api/v1alpha1/edgeworkload_webhook_test.go
@@ -205,5 +205,23 @@ var _ = Describe("EdgeWorkload Webhook", func() {
 			Expect(err).Should(MatchError("name collisions for containers within the same pod spec are not supported.\n" +
 				"container name: 'container' has been reused"))
 		})
+
+		It("set port 9100 for edge workload", func() {
+			// given
+			podSpec.InitContainers = append(edgeWorkload.Spec.Pod.Spec.Containers,
+				corev1.Container{
+					Ports: []corev1.ContainerPort{
+						{
+							HostPort: 9100,
+						},
+					},
+				})
+
+			// when
+			err := edgeWorkload.ValidateCreate()
+
+			// then
+			Expect(err).Should(MatchError("HostPort 9100 is reserved for internal use on the device and cannot be set for user workloads"))
+		})
 	})
 })


### PR DESCRIPTION
This PR fixes #281.

Signed-off-by: arielireni <aireni@redhat.com>
