### PR TITLE
Fix: use of `ListenAndServe`

### DIFF
--- a/cmd/httpapi/main.go
+++ b/cmd/httpapi/main.go
@@ -184,7 +184,12 @@ func main() {
 	mux.Handle("/metrics", promhttp.HandlerFor(crmetrics.Registry, promhttp.HandlerOpts{}))
 	mux.HandleFunc("/healthz", httpOK)
 	mux.HandleFunc("/readyz", httpOK)
-	logger.Fatal(http.ListenAndServe(Config.MetricsAddr, mux))
+	metricsServer := &http.Server{
+		Addr:              Config.MetricsAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+	logger.Fatal(metricsServer.ListenAndServe())
 }
 
 func logger(logLevel string) (error, *zap.SugaredLogger) {


### PR DESCRIPTION
Currently the CI (security scanner) fails with the error:
```
[/github/workspace/cmd/httpapi/main.go:187] - G114 (CWE): Use of net/http serve function that has no support for setting timeouts (Confidence: HIGH, Severity: MEDIUM)
  186: 	mux.HandleFunc("/readyz", httpOK)
> 187: 	logger.Fatal(http.ListenAndServe(Config.MetricsAddr, mux))
  188: }
```

Signed-off-by: arielireni <aireni@redhat.com>

