### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         make test-create-coverage
         COVERAGE=$(go tool cover --func=cover.out |  grep total | grep -Eo '[0-9]+\.[0-9]+')
-        echo "coverage=${COVERAGE}" >> $GITHUB_OUTPUT
+        echo "coverage=${COVERAGE}" >> "$GITHUB_OUTPUT"
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         make test-create-coverage
         COVERAGE=$(go tool cover --func=cover.out |  grep total | grep -Eo '[0-9]+\.[0-9]+')
-        echo "::set-output name=coverage::${COVERAGE}"
+        echo "coverage=${COVERAGE}" >> $GITHUB_OUTPUT
 
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


